### PR TITLE
【頁面】加入 Product 詳細頁面 (畫廊未實裝)

### DIFF
--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -1,9 +1,27 @@
+const db = require('../models')
+const Product = db.Product
+
 module.exports = {
   getProducts: (req, res) => {
     res.send('products')
   },
 
-  getProduct: (req, res) => {
-    res.render('product')
+  getProduct: async (req, res) => {
+    try {
+      const product = await Product.findByPk(+req.params.id, { 
+        include: ['Gifts', 'Images', 'tags', 'Series'] 
+      })
+      console.log(product.dataValues)
+      product.mainImg = product.Images[0].url
+      product.release = product.releaseDate.toLocaleDateString()
+      product.dead = product.deadline.toLocaleDateString()
+      product.hasGift = product.Gifts.length !== 0 ? true : false
+
+      res.render('product', { product })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
   }
 }

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -14,11 +14,14 @@ module.exports = {
       const product = await Product.findByPk(+req.params.id, { 
         include: ['Gifts', 'Images', 'tags', 'Series'] 
       })
+
+      // 頁面所需 data
       product.mainImg = product.Images[0].url
       product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
       product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')
       product.deadlineFormat = moment(product.deadline).format('YYYY年MM月DD日(dd)')
       product.hasGift = product.Gifts.length !== 0 ? true : false
+      product.isOnSale = moment(new Date).isAfter(product.deadline)
 
       res.render('product', { css: 'product', product })
 

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -16,7 +16,7 @@ module.exports = {
       })
 
       // 頁面所需 data
-      product.mainImg = product.Images[0].url
+      product.mainImg = product.Images.find(img => img.isMain).url
       product.priceFormat = product.price.toLocaleString()
       product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
       product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -17,6 +17,7 @@ module.exports = {
 
       // 頁面所需 data
       product.mainImg = product.Images[0].url
+      product.priceFormat = product.price.toLocaleString()
       product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
       product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')
       product.deadlineFormat = moment(product.deadline).format('YYYY年MM月DD日(dd)')

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -20,8 +20,9 @@ module.exports = {
       product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
       product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')
       product.deadlineFormat = moment(product.deadline).format('YYYY年MM月DD日(dd)')
-      product.hasGift = product.Gifts.length !== 0 ? true : false
+      product.hasGift = (product.Gifts.length !== 0) ? true : false
       product.isOnSale = moment(new Date).isAfter(product.deadline)
+      product.hasInv = (product.inventory !== 0)
 
       res.render('product', { css: 'product', product })
 

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -1,6 +1,9 @@
 const db = require('../models')
 const Product = db.Product
 
+const moment = require('moment')
+moment.locale('zh-tw')
+
 module.exports = {
   getProducts: (req, res) => {
     res.send('products')
@@ -11,10 +14,10 @@ module.exports = {
       const product = await Product.findByPk(+req.params.id, { 
         include: ['Gifts', 'Images', 'tags', 'Series'] 
       })
-      console.log(product.dataValues)
       product.mainImg = product.Images[0].url
-      product.release = product.releaseDate.toLocaleDateString()
-      product.dead = product.deadline.toLocaleDateString()
+      product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
+      product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')
+      product.deadlineFormat = moment(product.deadline).format('YYYY年MM月DD日(dd)')
       product.hasGift = product.Gifts.length !== 0 ? true : false
 
       res.render('product', { product })

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -1,5 +1,9 @@
 module.exports = {
   getProducts: (req, res) => {
     res.send('products')
+  },
+
+  getProduct: (req, res) => {
+    res.render('product')
   }
 }

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -20,7 +20,7 @@ module.exports = {
       product.deadlineFormat = moment(product.deadline).format('YYYY年MM月DD日(dd)')
       product.hasGift = product.Gifts.length !== 0 ? true : false
 
-      res.render('product', { product })
+      res.render('product', { css: 'product', product })
 
     } catch (err) {
       console.error(err)

--- a/migrations/20191218031353-create-image.js
+++ b/migrations/20191218031353-create-image.js
@@ -14,6 +14,10 @@ module.exports = {
       product_id: {
         type: Sequelize.INTEGER
       },
+      is_main: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false
+      },
       created_at: {
         allowNull: false,
         type: Sequelize.DATE,

--- a/models/image.js
+++ b/models/image.js
@@ -2,7 +2,8 @@
 module.exports = (sequelize, DataTypes) => {
   const Image = sequelize.define('Image', {
     url: DataTypes.STRING,
-    ProductId: DataTypes.INTEGER
+    ProductId: DataTypes.INTEGER,
+    isMain: DataTypes.BOOLEAN
   }, {});
   Image.associate = function(models) {
     Image.belongsTo(models.Product)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express-handlebars": "^3.1.0",
     "express-session": "^1.17.0",
     "method-override": "^3.0.0",
+    "moment": "^2.24.0",
     "mysql2": "^2.0.2",
     "passport": "^0.4.1",
     "passport-local": "^1.0.0",

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -25,7 +25,7 @@
   border: 1px solid #ff9600;
 }
 
-.category-bar {
+.category-bar, footer {
   background-color: #806d66;
 }
 
@@ -60,7 +60,7 @@
   color:#454545;
 }
 
-.search-bar, footer{
+.search-bar {
   background-color: #b7a69f;
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,1 +1,69 @@
-/* sample */
+* {
+  box-sizing: border-box;
+}
+
+.btn-top-bar {
+  background-color: #ff9600;
+  border: 1px solid #ff9600;
+  color: #804000;
+}
+
+.btn-top-bar:hover {
+  background-color: #ff9600;
+  border: 1px solid #ff9600;
+  color: #804000;
+}
+
+.btn-orange {
+  background-color: #ff9600;
+  border: 1px solid #ff9600;
+  color: #ffffff;
+}
+
+.btn-orange:hover {
+  background-color: #ff9600;
+  border: 1px solid #ff9600;
+}
+
+.category-bar {
+  background-color: #806d66;
+}
+
+.footer-item {
+  display: inline;
+  border-right: 1px solid #ffffff;
+}
+
+.footer-item:last-child {
+  border-right: none;
+}
+.footer-link {
+  color: #ffffff;
+}
+.footer-link:hover {
+  color:#ffffff;
+}
+
+.navbar {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.nav-link {
+  color: #ffffff;
+  display: block;
+  text-decoration:none;
+}
+
+.nav-link:hover{
+  background-color:#eee;
+  color:#454545;
+}
+
+.search-bar, footer{
+  background-color: #b7a69f;
+}
+
+.footer-muted{
+  color: #ffffff;
+}

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -1,0 +1,125 @@
+p {
+  margin: 0;
+}
+
+.main-bg {
+  background: #ebebeb;
+}
+
+section {
+  border-radius: 20px;
+}
+
+/* 麵包屑 */
+.bread {
+  font-size: .85rem;
+}
+
+.bread a {
+  color: #707070;
+}
+
+/* 圖片畫廊 */
+.arrow-btn {
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+.img-list {
+  width: 500px;
+  overflow: hidden;
+  text-align: left;
+}
+
+.img-list img {
+  width: 70px;
+  height: 70px;
+}
+
+/* Tag 群 */
+.tag-icon {
+  font-weight: bold;
+  padding: .5rem;
+  border-radius: 5px;
+  font-size: .85rem;
+}
+
+.tag-icon.icon1 {  /* 預購中 */
+  background: #34a853; 
+  color: #fff;
+}
+
+.tag-icon.icon2 {  /* 特典 */
+  background: #ffe14d; 
+  color: #e53900;
+}
+
+.tag-icon.icon3 {  /* 庫存販售商品 */
+  background: #34a853;
+  color: #fff;
+}
+
+/* 上部購物車 */
+.small-text {
+  font-size: 12px;
+}
+
+.status-text {
+  color: #228b22;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.cart-btn {
+  display: inline-block;
+  background: #ff5400;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 10px;
+}
+
+.cart-btn-lg {
+  width: 80%;
+  height: 100px;
+  font-size: 1.5rem;
+}
+
+.cart-btn-sm {
+  width: 190px;
+  height: 70px;
+  font-size: 1rem;
+}
+
+.qty-select {
+  width: 80px;
+  background: #f0ebe5;
+  border-color: #e0dbd3;
+  height: 1.5rem;
+  padding-left: .5rem;
+}
+
+.qty-select:focus {
+  outline: none;
+}
+
+.buy-info {
+  font-size: 12px;
+  color: #ff0000;
+}
+
+/* 商品介紹 */
+.slogan {
+  color: #ff6600;
+  font-size: 1.2rem;
+}
+
+/* 商品規格 */
+.list-group-item:nth-of-type(odd) {
+  background: #f8f8f8;
+}
+
+.list-group li {
+  border-right: 0;
+  border-left: 0;
+  border-bottom: 0;
+}

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -20,6 +20,13 @@ section {
 }
 
 /* 圖片畫廊 */
+.prod-img {
+  width: 530px;
+  height: 670px;
+  margin: 0 auto;
+  background: #eee;
+}
+
 .arrow-btn {
   font-size: 2rem;
   cursor: pointer;
@@ -111,6 +118,13 @@ section {
 .slogan {
   color: #ff6600;
   font-size: 1.2rem;
+}
+
+/* 特典區塊 */
+.gift-img {
+  width: 100%;
+  height: 100%;
+  background: #eee;
 }
 
 /* 商品規格 */

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -8,6 +8,7 @@ p {
 
 section {
   border-radius: 20px;
+  background: #fff;
 }
 
 /* 麵包屑 */
@@ -41,6 +42,10 @@ section {
 .img-list img {
   width: 70px;
   height: 70px;
+}
+
+.gallery {
+  width: 1000px;
 }
 
 /* Tag 群 */

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -49,21 +49,8 @@ section {
   padding: .5rem;
   border-radius: 5px;
   font-size: .85rem;
-}
-
-.tag-icon.icon1 {  /* 預購中 */
-  background: #34a853; 
-  color: #fff;
-}
-
-.tag-icon.icon2 {  /* 特典 */
   background: #ffe14d; 
   color: #e53900;
-}
-
-.tag-icon.icon3 {  /* 庫存販售商品 */
-  background: #34a853;
-  color: #fff;
 }
 
 /* 上部購物車 */

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -64,6 +64,12 @@ section {
   font-weight: bold;
 }
 
+.status-sold-out {
+  color: #d83820;
+  font-size: 16px;
+  font-weight: bold;
+}
+
 .cart-btn {
   display: inline-block;
   background: #ff5400;

--- a/routes/products.js
+++ b/routes/products.js
@@ -3,5 +3,6 @@ const prodCtrller = require('../controllers/prodCtrller.js')
 
 // route base '/products'
 router.get('/', prodCtrller.getProducts)
+router.get('/:id', prodCtrller.getProduct)
 
 module.exports = router

--- a/seeders/20191218080007-product-seeder.js
+++ b/seeders/20191218080007-product-seeder.js
@@ -11,7 +11,7 @@ module.exports = {
        Array.from({ length: 20 }, (val, index) => ({
          name: faker.commerce.productName(),
          price: faker.commerce.price(1000,8000),
-         inventory: randomNum(30, 50),
+         inventory: index === 1 ? 0 : randomNum(30, 50),
          slogan: faker.lorem.words(),
          description: faker.lorem.lines(2),
          spec: faker.lorem.sentence(),

--- a/seeders/20191218114425-image-seeder.js
+++ b/seeders/20191218114425-image-seeder.js
@@ -7,12 +7,23 @@ function randomNum(min, max) {
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.bulkInsert('Images',
-      Array.from({ length: 60 }, (val, index) => ({
-        url: faker.image.imageUrl(530, 670),
-        product_id: index < 7 ? 1 : randomNum(1, 20)
-      }))
-    )
+    return Promise.all([
+      queryInterface.bulkInsert('Images',
+        Array.from({ length: 20 }, (val, index) => ({
+          url: faker.image.imageUrl(530, 670, 'cats'),
+          product_id: index + 1,
+          is_main: true
+        }))
+      ),
+      queryInterface.bulkInsert('Images',
+        Array.from({ length: 60 }, (val, index) => ({
+          url: faker.image.imageUrl(530, 670),
+          product_id: index < 6 ? 1 : randomNum(2, 20),
+          is_main: false
+        }))
+      )
+    ]) 
+    
   },
 
   down: (queryInterface, Sequelize) => {

--- a/seeders/20191218114425-image-seeder.js
+++ b/seeders/20191218114425-image-seeder.js
@@ -9,8 +9,8 @@ module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.bulkInsert('Images',
       Array.from({ length: 60 }, (val, index) => ({
-        url: faker.image.image(),
-        product_id: randomNum( 1, 20 )
+        url: faker.image.imageUrl(530, 670),
+        product_id: index < 7 ? 1 : randomNum(1, 20)
       }))
     )
   },

--- a/seeders/20191218121809-gift-seeder.js
+++ b/seeders/20191218121809-gift-seeder.js
@@ -4,7 +4,7 @@ const faker = require('faker')
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.bulkInsert('Gifts',
-      Array.from({ length: 20 }, (val, index) => ({
+      Array.from({ length: 5 }, (val, index) => ({
         name: faker.commerce.productName(),
         image: faker.image.image(),
         product_id: index + 1

--- a/seeders/20191218125001-tag-seeder.js
+++ b/seeders/20191218125001-tag-seeder.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    const tag = ['預購中', '特典', '庫存販售商品']
+    const tag = ['預購中', '附特典', '庫存販售商品']
     return queryInterface.bulkInsert('Tags',
       tag.map((item, index) => ({
         name: item,

--- a/seeders/20191218130133-tagItem-seeder.js
+++ b/seeders/20191218130133-tagItem-seeder.js
@@ -10,7 +10,7 @@ module.exports = {
         }))
       ),
       queryInterface.bulkInsert('Tag_items',
-        Array.from({ length: 20 }, (val, index) => ({
+        Array.from({ length: 5 }, (val, index) => ({
           tag_Id: 2,
           product_id: index + 1
         }))

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -16,8 +16,28 @@
   <title>GreatSmile Online Shop</title>
 </head>
 <body>
+  {{> header}}
   {{{body}}}
-
+  <footer class="container-fluid py-3 text-center">
+    <ul class="footer-bar mx-auto">
+      <li class="footer-item px-3">
+        <a class="footer-link py-4" href="/products">製品一覽</a>
+      </li>
+      <li class="footer-item px-3">
+        <a class="footer-link py-4" href="/figure">Figure</a>
+      </li>
+      <li class="footer-item px-3">
+        <a class="footer-link py-4" href="/豆丁人">豆丁人</a>
+      </li>
+      <li class="footer-item px-3">
+        <a class="footer-link py-4" href="/figma">Figma</a>
+      </li>
+      <li class="footer-item px-3">
+        <a class="footer-link py-4" href="/組裝模型(仮)">組裝模型(仮)</a>
+      </li>
+    </ul>
+    <span class="footer-muted">© 2019 最終溫蒂蕃茄堡</span>
+  </footer>
   <!-- included script -->
   <import>
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -1,0 +1,45 @@
+<nav class="navbar navbar-light bg-light">
+  <div class="container py-3">
+    <a class="navbar-brand">LOGO</a>
+    <div>
+      <a class="btn btn-primary mr-2 btn-top-bar" href="/signin">登入·註冊</a>
+      <a class="btn btn-primary btn-top-bar" href="/cart">購物車</a>
+    </div>
+  </div>
+
+  <div class="container-fluid category-bar">
+    <ul class="nav mx-auto">
+      <li class="nav-item px-3">
+        <a class="nav-link py-4" href="/products">製品一覽</a>
+      </li>
+      <li class="nav-item px-3">
+        <a class="nav-link py-4" href="/figure">Figure</a>
+      </li>
+      <li class="nav-item px-3">
+        <a class="nav-link py-4" href="/豆丁人">豆丁人</a>
+      </li>
+      <li class="nav-item px-3">
+        <a class="nav-link py-4" href="/figma">Figma</a>
+      </li>
+      <li class="nav-item px-3">
+        <a class="nav-link py-4" href="/組裝模型(仮)">組裝模型(仮)</a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="container-fluid py-2 search-bar">
+    <div class="row mx-auto">
+      <div class="col-md-12 ">
+        <div class="input-group">
+          <input type="text" class="form-control" placeholder="Recipient's username" aria-label="Recipient's username"
+            aria-describedby="button-addon2">
+          <div class="input-group-append">
+            <button class="btn btn-outline-secondary btn-orange" type="button" id="button-addon2">
+              <i class="fas fa-search"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-light bg-light">
+<nav class="navbar navbar-light bg-light p-0">
   <div class="container py-3">
     <a class="navbar-brand">LOGO</a>
     <div>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -1,67 +1,95 @@
-<div class="py-5" style="background: #ebebeb">
-  <div class="container">
-    <h3>商品詳細</h3>
-    <section class="mb-5" style="background: #fff;">
+<div class="main-bg">
+  <main class="container pt-2 pb-5">
+    {{!-- 麵包屑 --}}
+    <nav class="bread mb-3">
+      <a href="/">Home </a>&gt;
+      <a href="/products&cate=figure">Figure </a>&gt;
+      <span>{{product.name}}</span>
+    </nav>
+    {{!-- main content --}}
+    <section class="mb-5 p-5" style="background: #fff;">
       {{!-- 圖片區塊 --}}
-      <div class="row py-4 px-5">
+      <div class="row pb-4">
+        {{!-- 畫廊 --}}
         <div class="col-md-8 text-center">
-          <img src="{{product.mainImg}}" alt="photo" width="530" height="653">
+          <img src="{{product.mainImg}}" alt="photo" width="70%">
           <div class="mt-4 d-flex justify-content-center align-items-center">
-            <div>左</div>
-            <div class="mx-3" style="
-              width: 400px;
-              overflow: auto;
-              text-align: left;
-            ">
+            <span class="arrow-btn">
+              <i class="fas fa-angle-left"></i>
+            </span>            
+            <div class="img-list mx-3">
               <div class="d-inline-block" style="width: 1000px">
                 {{#each product.Images}}
-                  <img src="{{url}}" alt="photo_list" width="70" height="70">
+                  <img src="{{url}}" alt="photo_list" class="mr-3 img-thumbnail">
                 {{/each}}
               </div>
             </div>
-            <div>右</div>
+            <span class="arrow-btn">
+              <i class="fas fa-angle-right"></i>
+            </span>
           </div>
         </div>
+        {{!-- info、購物車 --}}
         <div class="col-md-4">
-          <div>
+          <div class="mb-3 pt-1">
             {{#each product.tags}}
-              <button>{{name}}</button>
+              <span class="tag-icon icon{{id}} mr-2">{{name}}</span>
             {{/each}}
           </div>
           <div>
-            <h4>{{product.name}}</h4>
-            <p>作品名: {{product.Series.name}}</p>
-            <p>發售月: {{product.saleDateFormat}}</p>
-            <p>NT {{product.price}}</p>
+            <h4 class="mb-3">{{product.name}}</h4>
+            <p class="mb-1">作品名:　{{product.Series.name}}</p>
+            <p>發售月:　{{product.saleDateFormat}}</p>
           </div>
-          <div class="border py-5">
-            <form action="#" method="POST">
-              <button class="d-block">加入購物車</button>
-              <span>數量</span>
-              <input type="number" value="1">
-              <span>接受預約中</span>
+          <hr>
+          <div class="small-text">
+            <form id="postCart" action="#" method="POST" class="h-100">
+              <div class="form-group text-center">
+                <button class="cart-btn cart-btn-lg btn">
+                  <i class="fas fa-cart-arrow-down"></i>
+                  <span>　加入購物車</span>
+                </button>
+              </div>
+              <div class="form-group mb-0 text-center">
+                <p class="mb-2 status-text">發售中</p>
+                <hr class="my-2">
+                <div class="d-flex px-3 mb-2 justify-content-between align-items-center">
+                  <span>數量</span>
+                  <select class="qty-select" name="quantity">
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                  </select>
+                </div>
+                <hr class="my-2">
+                <div class="d-flex px-3 justify-content-between align-items-center">
+                  <span>價格</span>
+                  <span>NT {{product.price}}</span>
+                </div>
+              </div>
             </form>
           </div>
-          <div>
-            <p>※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-            <p>※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+          <hr class="my-2">
+          <div class="buy-info">
+            <p>※ おひとり様3つまでの販売となります。上限数を超えるご注文に関しましては、キャンセルさせていただきます。</p>
+            <p>※ ご注文後のキャンセルにつきましては、一切お受け致しておりません。</p>
           </div>
         </div>
       </div>
       {{!-- 說明區塊 --}}
       <hr>
-      <div class="row py-4 px-5">
-        <div class="col-md-2">商品介紹</div>
+      <div class="row py-4">
+        <div class="col-md-2 font-weight-bold">商品介紹</div>
         <div class="col-md-10">
-          <p class="text-warning">{{product.slogan}}</p>
+          <p class="slogan">{{product.slogan}}</p>
           <p>{{product.description}}</p>
-          <p>&copy; {{product.copyright}}</p>
+          <p class="mt-5">&copy; {{product.copyright}}</p>
         </div>
       </div>
       <hr>
       {{!-- 受理期間 --}}
-      <div class="row py-4 px-5">
-        <div class="col-md-2">受理期間</div>
+      <div class="row py-4">
+        <div class="col-md-2 font-weight-bold">受理期間</div>
         <div class="col-md-10">
           <p>【受注生產】{{product.releaseDateFormat}} 12:00 開始 {{product.deadlineFormat}} 21:00 結束。</p>
           <p>※ 無庫存時販售終止</p>
@@ -70,9 +98,9 @@
       <hr>
       {{!-- 特典 --}}
       {{#if product.hasGift}}
-      <div class="row py-4 px-5">
+      <div class="row py-4">
         <div class="col-md-2">
-          <button>特典</button>
+          <span class="tag-icon icon2">特典</span>
         </div>
         <div class="col-md-6">
           <p>【GREATSMILE ONLINE SHOP予約特典】</p>
@@ -85,54 +113,86 @@
       <hr>
       {{/if}}
       {{!-- 價格、購物車 --}}
-      <div class="row py-4 px-5">
-        <div class="col-md-2">價格</div>
+      <div class="row py-4">
+        <div class="col-md-2 font-weight-bold">價格</div>
         <div class="col-md-6">
-          <p>NT {{product.price}}</p>
-          <div>
-            <form action="#" method="POST">
-              <button class="d-block">加入購物車</button>
-              <span>數量</span>
-              <input type="number" value="1">
-              <span>接受預約中</span>
+          <small class="text-muted">NT {{product.price}}</small>
+          <div class="mt-2">
+            <form id="postCart" action="#" method="POST">
+              <div class="form-group">
+                <button class="cart-btn cart-btn-sm btn">
+                  <i class="fas fa-cart-arrow-down"></i>
+                  <span>　加入購物車</span>
+                </button>
+              </div>
+              <div>
+                <span class="mr-3">數量</span>
+                <select class="qty-select mr-3" name="quantity">
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                </select>
+                <span class="status-text">發售中</span>
+              </div>
             </form>
           </div>
         </div>
-        <div class="col-md-4">
-          <p>※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-          <p>※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <div class="col-md-4 buy-info">
+          <p>※ おひとり様3つまでの販売となります。上限数を超えるご注文に関しましては、キャンセルさせていただきます。</p>
+          <p>※ ご注文後のキャンセルにつきましては、一切お受け致しておりません。</p>
         </div>
       </div>
       <hr>
       {{!-- 規格 --}}
-      <div class="row py-4 px-5">
-        <div class="col-md-2">規格</div>
+      <div class="row py-4">
+        <div class="col-md-2 font-weight-bold">規格</div>
         <div class="col-md-10">
-          <div class="row pr-5">
-            <div class="col-md-3 py-2 border-top">商品名</div>
-            <div class="col-md-9 py-2 border-top">{{product.name}}</div>
-            <div class="col-md-3 py-2 border-top">發售月</div>
-            <div class="col-md-9 py-2 border-top">{{product.saleDateFormat}}</div>
-            <div class="col-md-3 py-2 border-top">公告日</div>
-            <div class="col-md-9 py-2 border-top">{{product.releaseDateFormat}}</div>
-            <div class="col-md-3 py-2 border-top">製造商</div>
-            <div class="col-md-9 py-2 border-top">{{product.maker}}</div>
-            <div class="col-md-3 py-2 border-top">作品名</div>
-            <div class="col-md-9 py-2 border-top">{{product.Series.name}}</div>
-            <div class="col-md-3 py-2 border-top">規格</div>
-            <div class="col-md-9 py-2 border-top">{{product.spec}}</div>
-          </div>
+          <ul class="list-group">
+            <li class="list-group-item">
+              <span class="mr-5">商品名</span>
+              <span>{{product.name}}</span>
+            </li>
+            <li class="list-group-item">
+              <span class="mr-5">發售月</span>
+              <span>{{product.saleDateFormat}}</span>
+            </li>
+            <li class="list-group-item">
+              <span class="mr-5">公告日</span>
+              <span>{{product.releaseDateFormat}}</span>
+            </li>
+            <li class="list-group-item">
+              <span class="mr-5">製造商</span>
+              <span>{{product.maker}}</span>
+            </li>
+            <li class="list-group-item">
+              <span class="mr-5">作品名</span>
+              <span>{{product.Series.name}}</span>
+            </li>
+            <li class="list-group-item border-bottom">
+              <span class="mr-5">規　格</span>
+              <span>{{product.spec}}</span>
+            </li>
+          </ul>
         </div>
       </div>
     </section>
-    <section class="mb-5" style="background: #fff;">
-      <div class="p-5">
-        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+    {{!-- waring info --}}
+    <section class="mb-5 p-5" style="background: #fff;">
+      <div class="small-text">
+        ※ 受注期間、予約受付期間内においても販売を終了する場合がございます。ご了承ください。
+        <br>
+        ※ 銀行振り込みの際は、ご注文番号のご記入をお忘れなくお願い致します。
+        <br>
+        ※ クレジットカードでのお支払いにつきましては、予約商品の場合、商品発送予定日が確定・ご案内させていただき次第、発送予定日の2～3週間前から順次決済手続きを行わせていただきます。
+        <br>
+        ※ Amazonペイメントサービスでのお支払いにつきましては、ご注文時に即時決済処理となりますのでご注意下さい。
+        <br>
+        ※ ご利用ガイドにも記載しております通り、ご注文後のキャンセルは承る事ができませんので、ご注文の際はご注意頂きますようお願い致します。
+        <br>
+        ※ 掲載の写真は実際の商品とは多少異なる場合があります。
+        <br>
+        ※ 商品の塗装は彩色工程が手作業になるため、商品個々に多少の差異があります。予めご了承ください。
       </div>
     </section>
-  </div>
-</div>
+  </main>
+</div> 

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -76,7 +76,7 @@
                 <hr class="my-2">
                 <div class="d-flex px-3 justify-content-between align-items-center">
                   <span>價格</span>
-                  <span>NT {{product.priceFormat}}</span>
+                  <span>NTD {{product.priceFormat}}</span>
                 </div>
               </div>
             </form>
@@ -134,7 +134,7 @@
       <div class="row py-4">
         <div class="col-md-2 font-weight-bold">價格</div>
         <div class="col-md-6">
-          <small class="text-muted">NT {{product.priceFormat}}</small>
+          <small>NTD {{product.priceFormat}}</small>
           <div class="mt-2">
             <form id="postCart" action="#" method="POST">
               <div class="form-group">

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -103,8 +103,12 @@
       <div class="row py-4">
         <div class="col-md-2 font-weight-bold">受理期間</div>
         <div class="col-md-10">
-          <p>【受注生產】{{product.releaseDateFormat}} 12:00 開始 {{product.deadlineFormat}} 21:00 結束。</p>
-          <p>※ 無庫存時販售終止</p>
+          {{#if product.isOnSale}}
+            <s>【受注生產】{{product.releaseDateFormat}} 12:00 開始 {{product.deadlineFormat}} 21:00 結束。</s>
+            <p>※ 無庫存時販售終止</p>
+          {{else}}
+            <p>【受注生產】{{product.releaseDateFormat}} 12:00 開始 {{product.deadlineFormat}} 21:00 結束。</p>
+          {{/if}}
         </div>
       </div>
       <hr>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -11,8 +11,10 @@
       {{!-- 圖片區塊 --}}
       <div class="row pb-4">
         {{!-- 畫廊 --}}
-        <div class="col-md-8 text-center">
-          <img src="{{product.mainImg}}" alt="photo" width="70%">
+        <div class="col-md-8">
+          <div class="prod-img">
+            <img class="w-100" src="{{product.mainImg}}" alt="product-image">
+          </div>
           <div class="mt-4 d-flex justify-content-center align-items-center">
             <span class="arrow-btn">
               <i class="fas fa-angle-left"></i>
@@ -20,7 +22,7 @@
             <div class="img-list mx-3">
               <div class="d-inline-block" style="width: 1000px">
                 {{#each product.Images}}
-                  <img src="{{url}}" alt="photo_list" class="mr-3 img-thumbnail">
+                  <img src="{{url}}" alt="image-list" class="mr-3 img-thumbnail">
                 {{/each}}
               </div>
             </div>
@@ -107,7 +109,9 @@
           <p>「{{product.name}}」をご購入頂いた方に、「{{product.Gifts.0.name}}」をプレゼント！</p>
         </div>
         <div class="col-md-4">
-          <img class="w-100" src="{{product.Gifts.0.image}}" alt="特典圖">
+          <div class="gift-img">
+            <img class="w-100" src="{{product.Gifts.0.image}}" alt="gift-img">
+          </div>
         </div>
       </div>
       <hr>
@@ -195,4 +199,4 @@
       </div>
     </section>
   </main>
-</div> 
+</div>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -53,7 +53,11 @@
                 </button>
               </div>
               <div class="form-group mb-0 text-center">
-                <p class="mb-2 status-text">發售中</p>
+                {{#if product.isOnSale}}
+                  <p class="mb-2 status-text">發售中</p>
+                {{else}}
+                  <p class="mb-2 status-text">預約中</p>
+                {{/if}}
                 <hr class="my-2">
                 <div class="d-flex px-3 mb-2 justify-content-between align-items-center">
                   <span>數量</span>
@@ -136,7 +140,11 @@
                   <option value="2">2</option>
                   <option value="3">3</option>
                 </select>
-                <span class="status-text">發售中</span>
+                {{#if product.isOnSale}}
+                  <span class="status-text">發售中</span>
+                {{else}}
+                  <span class="status-text">預約中</span>
+                {{/if}}
               </div>
             </form>
           </div>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -33,11 +33,11 @@
         </div>
         {{!-- info、購物車 --}}
         <div class="col-md-4">
-          <div class="mb-3 pt-1">
-            {{#each product.tags}}
-              <span class="tag-icon icon{{id}} mr-2">{{name}}</span>
-            {{/each}}
-          </div>
+          {{#if product.hasGift}}
+            <div class="mb-3 pt-1">
+              <span class="tag-icon mr-2">附特典</span>
+            </div>
+          {{/if}}
           <div>
             <h4 class="mb-3">{{product.name}}</h4>
             <p class="mb-1">作品名:　{{product.Series.name}}</p>
@@ -106,7 +106,7 @@
       {{#if product.hasGift}}
       <div class="row py-4">
         <div class="col-md-2">
-          <span class="tag-icon icon2">特典</span>
+          <span class="tag-icon icon2">附特典</span>
         </div>
         <div class="col-md-6">
           <p>【GREATSMILE ONLINE SHOP予約特典】</p>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -47,14 +47,20 @@
           <div class="small-text">
             <form id="postCart" action="#" method="POST" class="h-100">
               <div class="form-group text-center">
-                <button class="cart-btn cart-btn-lg btn">
+                <button class="cart-btn cart-btn-lg btn"
+                  {{#unless product.hasInv}}disabled{{/unless}}
+                >
                   <i class="fas fa-cart-arrow-down"></i>
                   <span>　加入購物車</span>
                 </button>
               </div>
               <div class="form-group mb-0 text-center">
                 {{#if product.isOnSale}}
-                  <p class="mb-2 status-text">發售中</p>
+                  {{#if product.hasInv}}
+                    <p class="mb-2 status-text">發售中</p>
+                  {{else}}
+                    <p class="mb-2 status-sold-out">已售完</p>
+                  {{/if}}
                 {{else}}
                   <p class="mb-2 status-text">預約中</p>
                 {{/if}}
@@ -128,12 +134,14 @@
           <div class="mt-2">
             <form id="postCart" action="#" method="POST">
               <div class="form-group">
-                <button class="cart-btn cart-btn-sm btn">
+                <button class="cart-btn cart-btn-sm btn"
+                  {{#unless product.hasInv}}disabled{{/unless}}
+                >
                   <i class="fas fa-cart-arrow-down"></i>
                   <span>　加入購物車</span>
                 </button>
               </div>
-              <div>
+              <div class="d-flex align-items-center">
                 <span class="mr-3">數量</span>
                 <select class="qty-select mr-3" name="quantity">
                   <option value="1">1</option>
@@ -141,7 +149,11 @@
                   <option value="3">3</option>
                 </select>
                 {{#if product.isOnSale}}
-                  <span class="status-text">發售中</span>
+                  {{#if product.hasInv}}
+                    <span class="status-text">發售中</span>
+                  {{else}}
+                    <span class="status-sold-out">已售完</span>
+                  {{/if}}
                 {{else}}
                   <span class="status-text">預約中</span>
                 {{/if}}

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -7,7 +7,7 @@
       <span>{{product.name}}</span>
     </nav>
     {{!-- main content --}}
-    <section class="mb-5 p-5" style="background: #fff;">
+    <section class="mb-5 p-5">
       {{!-- 圖片區塊 --}}
       <div class="row pb-4">
         {{!-- 畫廊 --}}
@@ -20,7 +20,7 @@
               <i class="fas fa-angle-left"></i>
             </span>            
             <div class="img-list mx-3">
-              <div class="d-inline-block" style="width: 1000px">
+              <div class="d-inline-block gallery">
                 {{#each product.Images}}
                   <img src="{{url}}" alt="image-list" class="mr-3 img-thumbnail">
                 {{/each}}
@@ -205,7 +205,7 @@
       </div>
     </section>
     {{!-- waring info --}}
-    <section class="mb-5 p-5" style="background: #fff;">
+    <section class="mb-5 p-5">
       <div class="small-text">
         ※ 受注期間、予約受付期間内においても販売を終了する場合がございます。ご了承ください。
         <br>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -5,7 +5,7 @@
       {{!-- 圖片區塊 --}}
       <div class="row py-4 px-5">
         <div class="col-md-8 text-center">
-          <img src="https://via.placeholder.com/530x653" alt="photo">
+          <img src="{{product.mainImg}}" alt="photo" width="530" height="653">
           <div class="mt-4 d-flex justify-content-center align-items-center">
             <div>左</div>
             <div class="mx-3" style="
@@ -14,24 +14,25 @@
               text-align: left;
             ">
               <div class="d-inline-block" style="width: 1000px">
-                <img src="https://via.placeholder.com/70" alt="photo_list">
-                <img src="https://via.placeholder.com/70" alt="photo_list">
-                <img src="https://via.placeholder.com/70" alt="photo_list">
-                <img src="https://via.placeholder.com/70" alt="photo_list">
-                <img src="https://via.placeholder.com/70" alt="photo_list">
-                <img src="https://via.placeholder.com/70" alt="photo_list">
+                {{#each product.Images}}
+                  <img src="{{url}}" alt="photo_list" width="70" height="70">
+                {{/each}}
               </div>
             </div>
             <div>右</div>
           </div>
         </div>
         <div class="col-md-4">
-          <span>Tag</span>
           <div>
-            <h4>Product Name</h4>
-            <p>作品名: Product Title</p>
-            <p>發售日: yyyy年mm月</p>
-            <p>NT price</p>
+            {{#each product.tags}}
+              <button>{{name}}</button>
+            {{/each}}
+          </div>
+          <div>
+            <h4>{{product.name}}</h4>
+            <p>作品名: {{product.Series.name}}</p>
+            <p>發售日: {{product.saleDate}}</p>
+            <p>NT {{product.price}}</p>
           </div>
           <div class="border py-5">
             <form action="#" method="POST">
@@ -52,9 +53,9 @@
       <div class="row py-4 px-5">
         <div class="col-md-2">商品介紹</div>
         <div class="col-md-10">
-          <p>slogan</p>
-          <p>desc</p>
-          <p>copyright</p>
+          <p class="text-warning">{{product.slogan}}</p>
+          <p>{{product.description}}</p>
+          <p>&copy; {{product.copyright}}</p>
         </div>
       </div>
       <hr>
@@ -62,28 +63,32 @@
       <div class="row py-4 px-5">
         <div class="col-md-2">受理期間</div>
         <div class="col-md-10">
-          <p>【受注生產】releaseDate 12:00 開始 deadline 21:00 結束。</p>
+          <p>【受注生產】{{product.release}} 12:00 開始 {{product.dead}} 21:00 結束。</p>
           <p>無庫存時販售終止</p>
         </div>
       </div>
       <hr>
       {{!-- 特典 --}}
+      {{#if product.hasGift}}
       <div class="row py-4 px-5">
-        <div class="col-md-2">特典</div>
+        <div class="col-md-2">
+          <button>特典</button>
+        </div>
         <div class="col-md-6">
-          <p>【預約特典】</p>
-          <p>購買 Product.name 者，將獲得 Gift.name 一枚</p>
+          <p>【GREATSMILE ONLINE SHOP予約特典】</p>
+          <p>「{{product.name}}」をご購入頂いた方に、「{{product.Gifts.0.name}}」をプレゼント！</p>
         </div>
         <div class="col-md-4">
-          <img class="w-100" src="https://via.placeholder.com/361x400" alt="特典圖">
+          <img class="w-100" src="{{product.Gifts.0.image}}" alt="特典圖">
         </div>
       </div>
       <hr>
+      {{/if}}
       {{!-- 價格、購物車 --}}
       <div class="row py-4 px-5">
         <div class="col-md-2">價格</div>
         <div class="col-md-6">
-          <p>NT Product.price</p>
+          <p>NT {{product.price}}</p>
           <div>
             <form action="#" method="POST">
               <button class="d-block">加入購物車</button>
@@ -104,18 +109,18 @@
         <div class="col-md-2">規格</div>
         <div class="col-md-10">
           <div class="row pr-5">
-            <div class="col-md-9 py-2 border-top">Prodcut.name</div>
             <div class="col-md-3 py-2 border-top">商品名</div>
+            <div class="col-md-9 py-2 border-top">{{product.name}}</div>
             <div class="col-md-3 py-2 border-top">發售日期</div>
-            <div class="col-md-9 py-2 border-top">Prodcut.saleDate</div>
+            <div class="col-md-9 py-2 border-top">{{product.saleDate}}</div>
             <div class="col-md-3 py-2 border-top">公告日期</div>
-            <div class="col-md-9 py-2 border-top">Prodcut.releaseDate</div>
+            <div class="col-md-9 py-2 border-top">{{product.releaseDate}}</div>
             <div class="col-md-3 py-2 border-top">製造商</div>
-            <div class="col-md-9 py-2 border-top">Prodcut.maker</div>
+            <div class="col-md-9 py-2 border-top">{{product.maker}}</div>
             <div class="col-md-3 py-2 border-top">作品名</div>
-            <div class="col-md-9 py-2 border-top">Prodcut.Series.name</div>
+            <div class="col-md-9 py-2 border-top">{{product.Series.name}}</div>
             <div class="col-md-3 py-2 border-top">規格</div>
-            <div class="col-md-9 py-2 border-top">Prodcut.spec</div>
+            <div class="col-md-9 py-2 border-top">{{product.spec}}</div>
           </div>
         </div>
       </div>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -31,7 +31,7 @@
           <div>
             <h4>{{product.name}}</h4>
             <p>作品名: {{product.Series.name}}</p>
-            <p>發售日: {{product.saleDate}}</p>
+            <p>發售月: {{product.saleDateFormat}}</p>
             <p>NT {{product.price}}</p>
           </div>
           <div class="border py-5">
@@ -63,8 +63,8 @@
       <div class="row py-4 px-5">
         <div class="col-md-2">受理期間</div>
         <div class="col-md-10">
-          <p>【受注生產】{{product.release}} 12:00 開始 {{product.dead}} 21:00 結束。</p>
-          <p>無庫存時販售終止</p>
+          <p>【受注生產】{{product.releaseDateFormat}} 12:00 開始 {{product.deadlineFormat}} 21:00 結束。</p>
+          <p>※ 無庫存時販售終止</p>
         </div>
       </div>
       <hr>
@@ -111,10 +111,10 @@
           <div class="row pr-5">
             <div class="col-md-3 py-2 border-top">商品名</div>
             <div class="col-md-9 py-2 border-top">{{product.name}}</div>
-            <div class="col-md-3 py-2 border-top">發售日期</div>
-            <div class="col-md-9 py-2 border-top">{{product.saleDate}}</div>
-            <div class="col-md-3 py-2 border-top">公告日期</div>
-            <div class="col-md-9 py-2 border-top">{{product.releaseDate}}</div>
+            <div class="col-md-3 py-2 border-top">發售月</div>
+            <div class="col-md-9 py-2 border-top">{{product.saleDateFormat}}</div>
+            <div class="col-md-3 py-2 border-top">公告日</div>
+            <div class="col-md-9 py-2 border-top">{{product.releaseDateFormat}}</div>
             <div class="col-md-3 py-2 border-top">製造商</div>
             <div class="col-md-9 py-2 border-top">{{product.maker}}</div>
             <div class="col-md-3 py-2 border-top">作品名</div>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -76,7 +76,7 @@
                 <hr class="my-2">
                 <div class="d-flex px-3 justify-content-between align-items-center">
                   <span>價格</span>
-                  <span>NT {{product.price}}</span>
+                  <span>NT {{product.priceFormat}}</span>
                 </div>
               </div>
             </form>
@@ -134,7 +134,7 @@
       <div class="row py-4">
         <div class="col-md-2 font-weight-bold">價格</div>
         <div class="col-md-6">
-          <small class="text-muted">NT {{product.price}}</small>
+          <small class="text-muted">NT {{product.priceFormat}}</small>
           <div class="mt-2">
             <form id="postCart" action="#" method="POST">
               <div class="form-group">

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -1,0 +1,133 @@
+<div class="py-5" style="background: #ebebeb">
+  <div class="container">
+    <h3>商品詳細</h3>
+    <section class="mb-5" style="background: #fff;">
+      {{!-- 圖片區塊 --}}
+      <div class="row py-4 px-5">
+        <div class="col-md-8 text-center">
+          <img src="https://via.placeholder.com/530x653" alt="photo">
+          <div class="mt-4 d-flex justify-content-center align-items-center">
+            <div>左</div>
+            <div class="mx-3" style="
+              width: 400px;
+              overflow: auto;
+              text-align: left;
+            ">
+              <div class="d-inline-block" style="width: 1000px">
+                <img src="https://via.placeholder.com/70" alt="photo_list">
+                <img src="https://via.placeholder.com/70" alt="photo_list">
+                <img src="https://via.placeholder.com/70" alt="photo_list">
+                <img src="https://via.placeholder.com/70" alt="photo_list">
+                <img src="https://via.placeholder.com/70" alt="photo_list">
+                <img src="https://via.placeholder.com/70" alt="photo_list">
+              </div>
+            </div>
+            <div>右</div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <span>Tag</span>
+          <div>
+            <h4>Product Name</h4>
+            <p>作品名: Product Title</p>
+            <p>發售日: yyyy年mm月</p>
+            <p>NT price</p>
+          </div>
+          <div class="border py-5">
+            <form action="#" method="POST">
+              <button class="d-block">加入購物車</button>
+              <span>數量</span>
+              <input type="number" value="1">
+              <span>接受預約中</span>
+            </form>
+          </div>
+          <div>
+            <p>※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+            <p>※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+          </div>
+        </div>
+      </div>
+      {{!-- 說明區塊 --}}
+      <hr>
+      <div class="row py-4 px-5">
+        <div class="col-md-2">商品介紹</div>
+        <div class="col-md-10">
+          <p>slogan</p>
+          <p>desc</p>
+          <p>copyright</p>
+        </div>
+      </div>
+      <hr>
+      {{!-- 受理期間 --}}
+      <div class="row py-4 px-5">
+        <div class="col-md-2">受理期間</div>
+        <div class="col-md-10">
+          <p>【受注生產】releaseDate 12:00 開始 deadline 21:00 結束。</p>
+          <p>無庫存時販售終止</p>
+        </div>
+      </div>
+      <hr>
+      {{!-- 特典 --}}
+      <div class="row py-4 px-5">
+        <div class="col-md-2">特典</div>
+        <div class="col-md-6">
+          <p>【預約特典】</p>
+          <p>購買 Product.name 者，將獲得 Gift.name 一枚</p>
+        </div>
+        <div class="col-md-4">
+          <img class="w-100" src="https://via.placeholder.com/361x400" alt="特典圖">
+        </div>
+      </div>
+      <hr>
+      {{!-- 價格、購物車 --}}
+      <div class="row py-4 px-5">
+        <div class="col-md-2">價格</div>
+        <div class="col-md-6">
+          <p>NT Product.price</p>
+          <div>
+            <form action="#" method="POST">
+              <button class="d-block">加入購物車</button>
+              <span>數量</span>
+              <input type="number" value="1">
+              <span>接受預約中</span>
+            </form>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <p>※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+          <p>※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        </div>
+      </div>
+      <hr>
+      {{!-- 規格 --}}
+      <div class="row py-4 px-5">
+        <div class="col-md-2">規格</div>
+        <div class="col-md-10">
+          <div class="row pr-5">
+            <div class="col-md-9 py-2 border-top">Prodcut.name</div>
+            <div class="col-md-3 py-2 border-top">商品名</div>
+            <div class="col-md-3 py-2 border-top">發售日期</div>
+            <div class="col-md-9 py-2 border-top">Prodcut.saleDate</div>
+            <div class="col-md-3 py-2 border-top">公告日期</div>
+            <div class="col-md-9 py-2 border-top">Prodcut.releaseDate</div>
+            <div class="col-md-3 py-2 border-top">製造商</div>
+            <div class="col-md-9 py-2 border-top">Prodcut.maker</div>
+            <div class="col-md-3 py-2 border-top">作品名</div>
+            <div class="col-md-9 py-2 border-top">Prodcut.Series.name</div>
+            <div class="col-md-3 py-2 border-top">規格</div>
+            <div class="col-md-9 py-2 border-top">Prodcut.spec</div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="mb-5" style="background: #fff;">
+      <div class="p-5">
+        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p class="mb-0">※ Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+      </div>
+    </section>
+  </div>
+</div>


### PR DESCRIPTION
`GET /products/:id`  商品詳細頁面。
UI 跟資料顯示先搞定。

<img src="https://i.gyazo.com/4f6996b76b3c2e1663e89c068b8ee13a.png" width="300px">

**branch 主要內容**
- 實裝 product 詳細頁面
- 修改 seeder
  - Image 商品圖尺寸固定為 530x670
  - Image 各商品必只有一張圖為 main img
  - id 1 的商品，必有 7 張圖 (方便畫廊 UI 調整 width)
  - id 2 的商品，無庫存
  - 只有前 5 項商品有特典
  - "特典" 更名為 "附特典"
- 修改 Image table 欄位，加入 is_main (model 屬性為 isMain)
- 引入套件 momentjs 處理 Date

<br>

## 確認目標

● UI 相關
- 頁面符合 Wireframe
  - 右上方購物車 UI 有調整，目前與 Wireframe 不同
  - 畫廊的放大鏡按鈕，等實裝畫廊再考慮放不放
- 畫廊預設顯示的大圖為 Image isMain 圖片，根據 seeder 此圖必為貓
- 畫廊與特典圖片，目前有給上灰色背景暗示有內容，防止假圖 API 抓圖失敗

<br>

● 依 Product 資料產生改變
- id > 5 為無特典商品，應不顯示特典 Tag 與下方特典區塊
- id < 10 商品為發售中
  - 發售中商品，購物車下方應顯示「發售中」
  - 發售中商品「受理期間」區塊，應出現刪除線與 ※ 註記內容
  - 預約中商品，購物車下方應顯示「預約中」
  - 預約中商品「受理期間」區塊，應沒有刪除線與 ※ 註記內容
- id 2 商品為已售完，購物商按鈕應被禁用，下方顯示「已售完」

<br>

● 其他註記
- 右上方 Tag 僅會顯示 「附特典」，不顯示其他 Tag
- 回Top 按鈕未實裝
- 價格顯示一律都有位數 dots，ex. NT 10,000
- 受理期間與公告日會顯示星期幾，ex. (四) 
- 發售月僅顯示年月，ex. 2019年12月
- 購物車數量表單，前端 UI 限制為不超過 3 個