### PR TITLE
【頁面】後台商品總覽

### DIFF
--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -32,7 +32,7 @@ module.exports = {
         }
 
       })
-      res.render('admin/products', { products })
+      res.render('admin/products', { products, css: 'admin' })
     } catch (err) {
       console.error(err)
       res.status(500).json(err.toString())

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -1,5 +1,27 @@
+const db = require('../../models')
+const { Product, Category, Series, Image } = db
+
 module.exports = {
-  getProducts: (req, res) => {
-    res.send('admin products')
+  getProducts: async (req, res) => {
+    try {
+      const [products] = await Promise.all([
+        Product.findAll({
+          order: [['id', 'DESC']],
+          include: [Category, Series, Image]
+        })
+      ])
+
+      products.forEach(product => {
+        if (product.Images.length != 0) {
+          product.imageUrl = product.Images[0].url
+        } else {
+          product.imageUrl = 'https://citainsp.org/wp-content/uploads/2016/01/default.jpg'
+        }
+      })
+      res.render('admin/products', { products })
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
   }
 }

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -6,31 +6,32 @@ const moment = require('moment')
 module.exports = {
   getProducts: async (req, res) => {
     try {
-      const [products] = await Promise.all([
-        Product.findAll({
-          order: [['id', 'DESC']],
-          include: [Category, Series, Image]
-        })
-      ])
+      const products = await Product.findAll({
+        order: [['id', 'DESC']],
+        include: [Category, Series, Image]
+      })
+
 
       //判斷日期用
       const today = new Date()
 
       products.forEach(product => {
-        //寫入第一筆圖片, 若無商品圖則寫入無圖片圖示
+        //寫入主商品圖, 若無商品圖則寫入無圖片圖示
         if (product.Images.length != 0) {
-          product.imageUrl = product.Images[0].url
+          product.mainImg = product.Images.find(img => img.isMain).url
         } else {
-          product.imageUrl = 'https://citainsp.org/wp-content/uploads/2016/01/default.jpg'
+          product.mainImg = 'https://citainsp.org/wp-content/uploads/2016/01/default.jpg'
         }
 
         //判斷發售狀態
-        if (product.saleDate.valueOf() > today.valueOf()) {
-          product.saleStatus = '未發售'
+        if (moment(today).isBefore(product.saleDate)) {
+          product.saleStatus = '預約中'
         } else {
           product.saleStatus = '已發售'
         }
 
+        //售價加上dot
+        product.price = product.price.toLocaleString()
       })
       res.render('admin/products', { products, css: 'admin' })
     } catch (err) {

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -13,6 +13,9 @@ module.exports = {
         })
       ])
 
+      //判斷日期用
+      const today = new Date()
+
       products.forEach(product => {
         //寫入第一筆圖片, 若無商品圖則寫入無圖片圖示
         if (product.Images.length != 0) {
@@ -21,11 +24,14 @@ module.exports = {
           product.imageUrl = 'https://citainsp.org/wp-content/uploads/2016/01/default.jpg'
         }
 
-        //格式化日期
-        product.simplifySale = moment(product.saleDate).format('YYYY/MM/DD')
+        //判斷發售狀態
+        if (product.saleDate.valueOf() > today.valueOf()) {
+          product.saleStatus = '未發售'
+        } else {
+          product.saleStatus = '已發售'
+        }
 
       })
-      console.log(products[0])
       res.render('admin/products', { products })
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -37,5 +37,10 @@ module.exports = {
       console.error(err)
       res.status(500).json(err.toString())
     }
+  },
+
+  getAddPage: (req, res) => {
+    res.render('admin/new')
   }
+
 }

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -1,6 +1,8 @@
 const db = require('../../models')
 const { Product, Category, Series, Image } = db
 
+const moment = require('moment')
+
 module.exports = {
   getProducts: async (req, res) => {
     try {
@@ -12,12 +14,18 @@ module.exports = {
       ])
 
       products.forEach(product => {
+        //寫入第一筆圖片, 若無商品圖則寫入無圖片圖示
         if (product.Images.length != 0) {
           product.imageUrl = product.Images[0].url
         } else {
           product.imageUrl = 'https://citainsp.org/wp-content/uploads/2016/01/default.jpg'
         }
+
+        //格式化日期
+        product.simplifySale = moment(product.saleDate).format('YYYY/MM/DD')
+
       })
+      console.log(products[0])
       res.render('admin/products', { products })
     } catch (err) {
       console.error(err)

--- a/models/image.js
+++ b/models/image.js
@@ -2,9 +2,10 @@
 module.exports = (sequelize, DataTypes) => {
   const Image = sequelize.define('Image', {
     url: DataTypes.STRING,
-    ProductId: DataTypes.INTEGER
+    ProductId: DataTypes.INTEGER,
+    isMain: DataTypes.BOOLEAN
   }, {});
-  Image.associate = function(models) {
+  Image.associate = function (models) {
     Image.belongsTo(models.Product)
   };
   return Image;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express-handlebars": "^3.1.0",
     "express-session": "^1.17.0",
     "method-override": "^3.0.0",
+    "moment": "^2.24.0",
     "mysql2": "^2.0.2",
     "passport": "^0.4.1",
     "passport-local": "^1.0.0",

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -1,0 +1,16 @@
+.container {
+  max-width: 1250px;
+}
+
+#table > tbody {
+  font-size: 14px;
+}
+
+#table > thead {
+  background-color: #6c757d;
+  color: white;
+}
+
+.table-bordered td, .table-bordered th {
+    border: 0px solid #dee2e6;
+}

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -14,3 +14,9 @@
 .table-bordered td, .table-bordered th {
     border: 0px solid #dee2e6;
 }
+
+.card-body {
+    -ms-flex: 1 1 auto;
+    flex: 1 1 auto;
+    padding: 0rem;
+}

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -3,8 +3,16 @@ const prodCtrller = require('../../controllers/admin/prodCtrller.js')
 
 const { isAdminAuth } = require('../../middleware/auth')
 
+
+
 // route base '/admin'
 router.use('/', isAdminAuth)
+// set admin layout
+router.use('/', (req, res, next) => {
+  res.locals.layout = 'admin'
+  next()
+})
+
 router.get('/', (req, res) => res.redirect('/admin/products'))
 router.get('/products', prodCtrller.getProducts)
 router.get('/products/new', prodCtrller.getAddPage)

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -7,5 +7,6 @@ const { isAdminAuth } = require('../../middleware/auth')
 router.use('/', isAdminAuth)
 router.get('/', (req, res) => res.redirect('/admin/products'))
 router.get('/products', prodCtrller.getProducts)
+router.get('/products/new', prodCtrller.getAddPage)
 
 module.exports = router

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -3,16 +3,13 @@ const prodCtrller = require('../../controllers/admin/prodCtrller.js')
 
 const { isAdminAuth } = require('../../middleware/auth')
 
-
-
-// route base '/admin'
-router.use('/', isAdminAuth)
-// set admin layout
-router.use('/', (req, res, next) => {
+// 判斷 admin 權限，set admin layout
+router.use('/', isAdminAuth, (req, res, next) => {
   res.locals.layout = 'admin'
   next()
 })
 
+// route base '/admin'
 router.get('/', (req, res) => res.redirect('/admin/products'))
 router.get('/products', prodCtrller.getProducts)
 router.get('/products/new', prodCtrller.getAddPage)

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -73,8 +73,8 @@
             <input type="date" class="form-control" id="saleDate">
           </div>
           <div class="form-group">
-            <label for="saleDate">發售日</label>
-            <input type="date" class="form-control" id="saleDate">
+            <label for="deadline">預購截止日</label>
+            <input type="date" class="form-control" id="deadline">
           </div>
         </div>
       </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -1,0 +1,83 @@
+<div class="card">
+  <div class="card-header">
+    <ul class="nav nav-tabs card-header-tabs">
+      <li class="nav-item">
+        <a class="nav-link active" href="/admin/products/new"><i class="fas fa-plus"></i> 新增商品</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/admin/products">商品</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/admin/orders">訂單</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/admin/users">會員</a>
+      </li>
+    </ul>
+  </div>
+  <div class="card-body">
+    <form action="/admin/products" method="POST" enctype="multipart/form-data">
+      <div class="row">
+        <div class="col-5 mx-auto">
+          <div class="form-group">
+            <label for="name">商品名稱</label>
+            <input type="text" class="form-control" id="name">
+          </div>
+          <div class="form-group">
+            <label for="slogan">標語</label>
+            <input type="text" class="form-control" id="slogan">
+          </div>
+          <div class="form-group">
+            <label for="deseription">介紹</label>
+            <textarea class="form-control" id="deseription"></textarea>
+          </div>
+          <div class="form-group">
+            <label for="image">商品圖片</label>
+            <input type="file" class="form-control-file" id="image" name="image">
+          </div>
+          <div class="form-group">
+            <label for="spec">規格</label>
+            <input type="text" class="form-control" id="spec">
+          </div>
+          <div class="form-group">
+            <label for="copyright">版權</label>
+            <input type="text" class="form-control" id="copyright">
+          </div>
+          <div class="form-group">
+            <label for="maker">廠商</label>
+            <input type="text" class="form-control" id="maker">
+          </div>
+        </div>
+        <div class="col-5 mx-auto">
+          <div class="form-group">
+            <label for="price">售價</label>
+            <input type="text" class="form-control" id="price">
+          </div>
+          <div class="form-group">
+            <label for="intenvory">庫存</label>
+            <input type="text" class="form-control" id="intenvory">
+          </div>
+          <div class="form-group">
+            <label for="state">上架狀態</label>
+            <select id="state" class="form-control">
+              <option selected>是</option>
+              <option>否</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="releaseDate">公開日期</label>
+            <input type="date" class="form-control" id="releaseDate">
+          </div>
+          <div class="form-group">
+            <label for="saleDate">發售日</label>
+            <input type="date" class="form-control" id="saleDate">
+          </div>
+          <div class="form-group">
+            <label for="saleDate">發售日</label>
+            <input type="date" class="form-control" id="saleDate">
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -24,7 +24,7 @@
         <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">庫存</th>
         <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
         <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">發售日期</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">發售狀態</th>
         <th colspan="4" class="text-center">商品操作</th>
       </tr>
       <tr>
@@ -47,7 +47,7 @@
           <td>{{this.inventory}}</td>
           <td>{{this.Category.name}}</td>
           <td>{{this.Series.name}}</td>
-          <td>{{this.simplifySale}}</td>
+          <td>{{this.saleStatus}}</td>
           <td>
             {{#if this.status}}
               <i class="far fa-circle text-success"></i>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -39,8 +39,8 @@
         <tr>
           <td>{{this.id}}</td>
           <td>
-            <img src="{{this.imageUrl}}" title="{{this.name}}" class="img-fluid rounded mx-auto d-block"
-              alt="productImage" style="width: 50px">
+            <img src="{{this.imageUrl}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
+              style="width:100%">
           </td>
           <td>{{this.name}}</td>
           <td>{{this.price}}</td>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -1,62 +1,62 @@
-<div class="container">
-  <main class="col-12">
-    <ul class="nav nav-tabs">
-      <li class="nav-item">
-        <a class="nav-link active" href="/admin/products">商品</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="/admin/orders">訂單</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="/admin/users">會員</a>
-      </li>
-    </ul>
-    <div class="mt-4">
-      <a href="/admin/products/new" class="btn btn-outline-secondary"><i class="fas fa-plus"></i> 新增商品</a>
-    </div>
-    <table data-toggle="table" data-search="true" data-show-columns="true" data-show-pagination-switch="true"
-      data-pagination="true" id="table">
-      <thead>
+<main class="col-12">
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link active" href="/admin/products">商品</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="/admin/orders">訂單</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="/admin/users">會員</a>
+    </li>
+  </ul>
+  <div class="mt-4">
+    <a href="/admin/products/new" class="btn btn-outline-secondary"><i class="fas fa-plus"></i> 新增商品</a>
+  </div>
+  <table data-toggle="table" data-search="true" data-show-columns="true" data-show-pagination-switch="true"
+    data-pagination="true" id="table">
+    <thead>
+      <tr>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">商品ID</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center">商品照片</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">名稱</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">售價</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">庫存</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">發售日期</th>
+        <th colspan="4" class="text-center">商品操作</th>
+      </tr>
+      <tr>
+        <th class="text-center" data-sortable="true">上架狀態</th>
+        <th class="text-center">編輯商品</th>
+        <th class="text-center">瀏覽商品</th>
+        <th class="text-center">刪除商品</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each products}}
         <tr>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">商品ID</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">商品照片</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">名稱</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">售價</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">庫存</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
-          <th colspan="4" class="text-center">商品操作</th>
+          <td>{{this.id}}</td>
+          <td>
+            <img src="{{this.imageUrl}}" title="{{this.name}}" class="img-fluid rounded mx-auto d-block"
+              alt="productImage" style="width: 50px">
+          </td>
+          <td>{{this.name}}</td>
+          <td>{{this.price}}</td>
+          <td>{{this.inventory}}</td>
+          <td>{{this.Category.name}}</td>
+          <td>{{this.Series.name}}</td>
+          <td>{{this.simplifySale}}</td>
+          <td>
+            {{#if this.status}}
+              <i class="far fa-circle text-success"></i>
+            {{else}}
+              <i class="fas fa-times text-danger"></i>
+            {{/if}}
+          </td>
         </tr>
-        <tr>
-          <th class="text-center" data-sortable="true">上架狀態</th>
-          <th class="text-center">編輯商品</th>
-          <th class="text-center">瀏覽商品</th>
-          <th class="text-center">刪除商品</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{#each products}}
-          <tr>
-            <td>{{this.id}}</td>
-            <td>
-              <img src="{{this.imageUrl}}" title="{{this.name}}" class="img-fluid rounded mx-auto d-block"
-                alt="productImage" style="width: 50px">
-            </td>
-            <td>{{this.name}}</td>
-            <td>{{this.price}}</td>
-            <td>{{this.inventory}}</td>
-            <td>{{this.Category.name}}</td>
-            <td>{{this.Series.name}}</td>
-            <td>
-              {{#if this.status}}
-                <i class="far fa-circle text-success"></i>
-              {{else}}
-                <i class="fas fa-times text-danger"></i>
-              {{/if}}
-            </td>
-          </tr>
-        {{/each}}
-      </tbody>
-    </table>
-  </main>
-</div>
+      {{/each}}
+    </tbody>
+  </table>
+</main>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -35,6 +35,20 @@
         </tr>
       </thead>
       <tbody>
+        {{#each products}}
+          <tr>
+            <td>{{this.id}}</td>
+            <td>
+              <img src="{{this.imageUrl}}" title="{{this.name}}" class="img-fluid rounded mx-auto d-block"
+                alt="productImage" style="width: 50px">
+            </td>
+            <td>{{this.name}}</td>
+            <td>{{this.price}}</td>
+            <td>{{this.inventory}}</td>
+            <td>{{this.Category.name}}</td>
+            <td>{{this.Series.name}}</td>
+          </tr>
+        {{/each}}
       </tbody>
     </table>
   </main>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -55,6 +55,11 @@
               <i class="fas fa-times text-danger"></i>
             {{/if}}
           </td>
+          <td></td>
+          <td>
+            <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block"><i
+                class="fas fa-external-link-alt"></i></a>
+          </td>
         </tr>
       {{/each}}
     </tbody>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -15,14 +15,16 @@
       <a href="/admin/products/new" class="btn btn-outline-secondary"><i class="fas fa-plus"></i> 新增商品</a>
     </div>
     <table data-toggle="table" data-search="true" data-show-columns="true" data-show-pagination-switch="true"
-      data-pagination="true">
+      data-pagination="true" id="table">
       <thead>
         <tr>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">商品ID</th>
           <th data-width="150" rowspan="2" data-valign="middle" class="text-center">商品照片</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">名稱</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">售價</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">模型分類</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">作品分類</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">名稱</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">售價</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">庫存</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
           <th colspan="4" class="text-center">商品操作</th>
         </tr>
         <tr>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -1,0 +1,39 @@
+<div class="container">
+  <main class="col-12">
+    <ul class="nav nav-tabs">
+      <li class="nav-item">
+        <a class="nav-link active" href="/admin/products">商品</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/admin/orders">訂單</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/admin/users">會員</a>
+      </li>
+    </ul>
+    <div class="mt-4">
+      <a href="/admin/products/new" class="btn btn-outline-secondary"><i class="fas fa-plus"></i> 新增商品</a>
+    </div>
+    <table data-toggle="table" data-search="true" data-show-columns="true" data-show-pagination-switch="true"
+      data-pagination="true">
+      <thead>
+        <tr>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">商品照片</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">名稱</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">售價</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">模型分類</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">作品分類</th>
+          <th colspan="4" class="text-center">商品操作</th>
+        </tr>
+        <tr>
+          <th class="text-center">上架狀態</th>
+          <th class="text-center">編輯商品</th>
+          <th class="text-center">瀏覽商品</th>
+          <th class="text-center">刪除商品</th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+  </main>
+</div>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -28,7 +28,7 @@
           <th colspan="4" class="text-center">商品操作</th>
         </tr>
         <tr>
-          <th class="text-center">上架狀態</th>
+          <th class="text-center" data-sortable="true">上架狀態</th>
           <th class="text-center">編輯商品</th>
           <th class="text-center">瀏覽商品</th>
           <th class="text-center">刪除商品</th>
@@ -47,6 +47,13 @@
             <td>{{this.inventory}}</td>
             <td>{{this.Category.name}}</td>
             <td>{{this.Series.name}}</td>
+            <td>
+              {{#if this.status}}
+                <i class="far fa-circle text-success"></i>
+              {{else}}
+                <i class="fas fa-times text-danger"></i>
+              {{/if}}
+            </td>
           </tr>
         {{/each}}
       </tbody>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -1,70 +1,74 @@
-<main class="col-12">
-  <ul class="nav nav-tabs">
-    <li class="nav-item">
-      <a class="nav-link active" href="/admin/products">商品</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="/admin/orders">訂單</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="/admin/users">會員</a>
-    </li>
-  </ul>
-  <div class="mt-4">
-    <a href="/admin/products/new" class="btn btn-outline-secondary"><i class="fas fa-plus"></i> 新增商品</a>
+<div class="card text-center">
+  <div class="card-header">
+    <ul class="nav nav-tabs card-header-tabs">
+      <li class="nav-item">
+        <a class="nav-link" href="/admin/products/new"><i class="fas fa-plus"></i> 新增商品</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" href="/admin/products">商品</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/admin/orders">訂單</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/admin/users">會員</a>
+      </li>
+    </ul>
   </div>
-  <table data-toggle="table" data-search="true" data-show-columns="true" data-show-pagination-switch="true"
-    data-pagination="true" id="table">
-    <thead>
-      <tr>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">商品ID</th>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center">商品照片</th>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">名稱</th>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">售價</th>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">庫存</th>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
-        <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">發售狀態</th>
-        <th colspan="4" class="text-center">商品操作</th>
-      </tr>
-      <tr>
-        <th class="text-center" data-sortable="true">上架狀態</th>
-        <th class="text-center">編輯商品</th>
-        <th class="text-center">瀏覽商品</th>
-        <th class="text-center">刪除商品</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{#each products}}
+  <div class="card-body">
+    <table data-toggle="table" data-search="true" data-show-columns="true" data-show-pagination-switch="true"
+      data-pagination="true" id="table">
+      <thead>
         <tr>
-          <td>{{this.id}}</td>
-          <td>
-            <img src="{{this.imageUrl}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
-              style="width:100%">
-          </td>
-          <td>{{this.name}}</td>
-          <td>{{this.price}}</td>
-          <td>{{this.inventory}}</td>
-          <td>{{this.Category.name}}</td>
-          <td>{{this.Series.name}}</td>
-          <td>{{this.saleStatus}}</td>
-          <td>
-            {{#if this.status}}
-              <i class="far fa-circle text-success"></i>
-            {{else}}
-              <i class="fas fa-times text-danger"></i>
-            {{/if}}
-          </td>
-          <td>
-            <a href="/admin/products/{{this.id}}" class="text-decoration-none text-dark d-block"><i
-                class="fas fa-edit"></i></a>
-          </td>
-          <td>
-            <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block"><i
-                class="fas fa-external-link-alt"></i></a>
-          </td>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">商品ID</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">商品照片</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">名稱</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">售價</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">庫存</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">發售狀態</th>
+          <th colspan="4" class="text-center">商品操作</th>
         </tr>
-      {{/each}}
-    </tbody>
-  </table>
-</main>
+        <tr>
+          <th class="text-center" data-sortable="true">上架狀態</th>
+          <th class="text-center">編輯商品</th>
+          <th class="text-center">瀏覽商品</th>
+          <th class="text-center">刪除商品</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each products}}
+          <tr>
+            <td>{{this.id}}</td>
+            <td>
+              <img src="{{this.imageUrl}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
+                style="width:100%">
+            </td>
+            <td>{{this.name}}</td>
+            <td>{{this.price}}</td>
+            <td>{{this.inventory}}</td>
+            <td>{{this.Category.name}}</td>
+            <td>{{this.Series.name}}</td>
+            <td>{{this.saleStatus}}</td>
+            <td>
+              {{#if this.status}}
+                <i class="far fa-circle text-success"></i>
+              {{else}}
+                <i class="fas fa-times text-danger"></i>
+              {{/if}}
+            </td>
+            <td>
+              <a href="/admin/products/{{this.id}}" class="text-decoration-none text-dark d-block"><i
+                  class="fas fa-edit"></i></a>
+            </td>
+            <td>
+              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block"><i
+                  class="fas fa-external-link-alt"></i></a>
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -41,10 +41,16 @@
           <tr>
             <td>{{this.id}}</td>
             <td>
-              <img src="{{this.imageUrl}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
-                style="width:100%">
+              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+                <img src="{{this.imageUrl}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
+                  style="width:100%">
+              </a>
             </td>
-            <td>{{this.name}}</td>
+            <td>
+              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+                {{this.name}}
+              </a>
+            </td>
             <td>{{this.price}}</td>
             <td>{{this.inventory}}</td>
             <td>{{this.Category.name}}</td>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -26,7 +26,7 @@
         <tr>
           <th data-valign="middle" class="text-center" data-sortable="true">#</th>
           <th data-valign="middle" class="text-center">商品照片</th>
-          <th data-valign="middle" class="text-center" data-sortable="true">名稱</th>
+          <th data-valign="middle" class="text-center" data-sortable="true" data-width="150">名稱</th>
           <th data-valign="middle" class="text-center" data-sortable="true">售價</th>
           <th data-valign="middle" class="text-center" data-sortable="true">庫存</th>
           <th data-valign="middle" class="text-center" data-sortable="true">模型分類</th>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -32,7 +32,7 @@
         <tr>
           <th class="text-center" data-sortable="true">上架狀態</th>
           <th class="text-center">編輯商品</th>
-          <th class="text-center">瀏覽商品</th>
+          <th class="text-center">詳細資訊</th>
           <th class="text-center">刪除商品</th>
         </tr>
       </thead>
@@ -62,10 +62,45 @@
                   class="fas fa-edit"></i></a>
             </td>
             <td>
-              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block"><i
-                  class="fas fa-external-link-alt"></i></a>
+              <a href="/admin/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+                <i class="fas fa-search-plus"></i>
+              </a>
+            </td>
+            <td>
+              <!-- Delete Button trigger modal -->
+              <button type="button" class="btn font-weight-normal" data-toggle="modal"
+                data-target="#delete_{{this.id}}">
+                <i class="far fa-trash-alt" aria-hidden="true"></i>
+              </button>
             </td>
           </tr>
+          {{!-- Delete modal --}}
+          <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
+            aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                </div>
+                <div class="modal-body">
+                  <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                    {{this.name}}</h5>
+                  </br>
+                  <h5 class="text-danger text-right">你真的要刪除這項商品嗎？</h5>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+                  <form action="/admin/products/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                    <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                    </button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
         {{/each}}
       </tbody>
     </table>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -16,14 +16,13 @@
     </ul>
   </div>
   <div class="card-body">
-    <table data-toggle="table" data-search="true" data-show-columns="true" data-show-pagination-switch="true"
-      data-pagination="true" id="table">
+    <table data-toggle="table" data-search="true" data-show-columns="true" data-pagination="true" id="table">
       <thead>
         <tr>
           <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">商品ID</th>
           <th data-width="150" rowspan="2" data-valign="middle" class="text-center">商品照片</th>
           <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">名稱</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">售價</th>
+          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">售價(NTD)</th>
           <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">庫存</th>
           <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
           <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">作品分類</th>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -58,9 +58,15 @@
             <td>{{this.saleStatus}}</td>
             <td>
               {{#if this.status}}
-                <i class="far fa-circle text-success"></i>
+                <form action="/admin/products/{{this.id}}/undisplay" method="POST">
+                  <input type="text" name="id" hidden>
+                  <button type="submit" class="btn" title="將此商品下架"><i class="far fa-circle text-success"></i></button>
+                </form>
               {{else}}
-                <i class="fas fa-times text-danger"></i>
+                <form action="/admin/products/{{this.id}}/display" method="POST">
+                  <input type="text" name="id" hidden>
+                  <button type="submit" class="btn" title="將此商品上架"><i class="fas fa-times text-danger"></i></button>
+                </form>
               {{/if}}
             </td>
             <td>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -70,7 +70,7 @@
               {{/if}}
             </td>
             <td>
-              <a href="/admin/products/{{this.id}}" class="text-decoration-none text-dark d-block"><i
+              <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark d-block"><i
                   class="fas fa-edit"></i></a>
             </td>
             <td>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -15,106 +15,111 @@
       </li>
     </ul>
   </div>
-  <div class="card-body">
-    <table data-toggle="table" data-search="true" data-show-columns="true" data-pagination="true" id="table">
-      <thead>
-        <tr>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">商品ID</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center">商品照片</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">名稱</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">售價(NTD)</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">庫存</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
-          <th data-width="150" rowspan="2" data-valign="middle" class="text-center" data-sortable="true">發售狀態</th>
-          <th colspan="4" class="text-center">商品操作</th>
-        </tr>
-        <tr>
-          <th class="text-center" data-sortable="true">上架狀態</th>
-          <th class="text-center">編輯商品</th>
-          <th class="text-center">詳細資訊</th>
-          <th class="text-center">刪除商品</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{#each products}}
+  <div class="container">
+    <div class="card-body">
+      <table data-toggle="table" data-search="true" data-show-columns="true" data-pagination="true" id="table">
+        <thead>
           <tr>
-            <td>{{this.id}}</td>
-            <td>
-              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
-                <img src="{{this.imageUrl}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
-                  style="width:100%">
-              </a>
-            </td>
-            <td>
-              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
-                {{this.name}}
-              </a>
-            </td>
-            <td>{{this.price}}</td>
-            <td>{{this.inventory}}</td>
-            <td>{{this.Category.name}}</td>
-            <td>{{this.Series.name}}</td>
-            <td>{{this.saleStatus}}</td>
-            <td>
-              {{#if this.status}}
-                <form action="/admin/products/{{this.id}}/undisplay" method="POST">
-                  <input type="text" name="id" hidden>
-                  <button type="submit" class="btn" title="將此商品下架"><i class="far fa-circle text-success"></i></button>
-                </form>
-              {{else}}
-                <form action="/admin/products/{{this.id}}/display" method="POST">
-                  <input type="text" name="id" hidden>
-                  <button type="submit" class="btn" title="將此商品上架"><i class="fas fa-times text-danger"></i></button>
-                </form>
-              {{/if}}
-            </td>
-            <td>
-              <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark d-block"><i
-                  class="fas fa-edit"></i></a>
-            </td>
-            <td>
-              <a href="/admin/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
-                <i class="fas fa-search-plus"></i>
-              </a>
-            </td>
-            <td>
-              <!-- Delete Button trigger modal -->
-              <button type="button" class="btn font-weight-normal" data-toggle="modal"
-                data-target="#delete_{{this.id}}">
-                <i class="far fa-trash-alt" aria-hidden="true"></i>
-              </button>
-            </td>
+            <th data-valign="middle" class="text-center" data-sortable="true">#</th>
+            <th data-valign="middle" class="text-center">商品照片</th>
+            <th data-valign="middle" class="text-center" data-sortable="true">名稱</th>
+            <th data-valign="middle" class="text-center" data-sortable="true">售價</th>
+            <th data-valign="middle" class="text-center" data-sortable="true">庫存</th>
+            <th data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
+            <th data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
+            <th data-valign="middle" class="text-center" data-sortable="true">發售狀態</th>
+            <th data-valign="middle" class="text-center" data-sortable="true">上架狀態</th>
+            <th data-valign="middle" class="text-center">商品操作</th>
           </tr>
-          {{!-- Delete modal --}}
-          <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
-            aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                  </button>
-                </div>
-                <div class="modal-body">
-                  <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
-                    {{this.name}}</h5>
-                  </br>
-                  <h5 class="text-danger text-right">你真的要刪除這項商品嗎？</h5>
-                </div>
-                <div class="modal-footer">
-                  <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
-                  <form action="/admin/products/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
-                    <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+          {{!-- <tr>
+            <th class="text-center" data-sortable="true">上架狀態</th>
+            <th class="text-center">編輯商品</th>
+            <th class="text-center">詳細資訊</th>
+            <th class="text-center">刪除商品</th>
+          </tr> --}}
+        </thead>
+        <tbody>
+          {{#each products}}
+            <tr>
+              <td>{{this.id}}</td>
+              <td>
+                <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+                  <img src="{{this.imageUrl}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
+                    style="height:50px">
+                </a>
+              </td>
+              <td>
+                <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+                  {{this.name}}
+                </a>
+              </td>
+              <td>{{this.price}}</td>
+              <td>{{this.inventory}}</td>
+              <td>{{this.Category.name}}</td>
+              <td>{{this.Series.name}}</td>
+              <td>{{this.saleStatus}}</td>
+              <td>
+                {{#if this.status}}
+                  <form action="/admin/products/{{this.id}}/undisplay" method="POST">
+                    <input type="text" name="id" hidden>
+                    <button type="submit" class="btn" title="將此商品下架"><i
+                        class="far fa-circle text-success"></br>上架中</i></button>
+                  </form>
+                {{else}}
+                  <form action="/admin/products/{{this.id}}/display" method="POST">
+                    <input type="text" name="id" hidden>
+                    <button type="submit" class="btn" title="將此商品上架"><i class="fas fa-times text-danger"></br>未上架</i>
                     </button>
                   </form>
+                {{/if}}
+              </td>
+              <td>
+                <button type="button" class="btn font-weight-normal">
+                  <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark "><i
+                      class="fas fa-edit" title="編輯此商品"></i></a>
+                </button>
+                <button type="button" class="btn font-weight-normal">
+                  <a href="/admin/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark ">
+                    <i class="fas fa-search-plus" title="商品詳情"></i>
+                  </a>
+                </button>
+                <!-- Delete Button trigger modal -->
+                <button type="button" class="btn font-weight-normal" data-toggle="modal"
+                  data-target="#delete_{{this.id}}" title="刪除此商品">
+                  <i class="far fa-trash-alt" aria-hidden="true"></i>
+                </button>
+              </td>
+            </tr>
+            {{!-- Delete modal --}}
+            <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
+              aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </div>
+                  <div class="modal-body">
+                    <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                      {{this.name}}</h5>
+                    </br>
+                    <h5 class="text-danger text-right">你真的要刪除這項商品嗎？</h5>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+                    <form action="/admin/products/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                      <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                      </button>
+                    </form>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        {{/each}}
-      </tbody>
-    </table>
+          {{/each}}
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -1,6 +1,7 @@
-<div class="card text-center">
-  <div class="card-header">
-    <ul class="nav nav-tabs card-header-tabs">
+<nav class="navbar fixed-top navbar-light bg-light">
+  <div class="container">
+    <ul class="nav nav-pills nav-fill">
+      <span class="navbar-brand mb-0 h1">LOGO</span>
       <li class="nav-item">
         <a class="nav-link" href="/admin/products/new"><i class="fas fa-plus"></i> 新增商品</a>
       </li>
@@ -13,113 +14,108 @@
       <li class="nav-item">
         <a class="nav-link" href="/admin/users">會員</a>
       </li>
+      <br>
     </ul>
+    <a class="btn btn-outline-secondary ml-3" href="/signout">登出</a>
   </div>
-  <div class="container">
-    <div class="card-body">
-      <table data-toggle="table" data-search="true" data-show-columns="true" data-pagination="true" id="table">
-        <thead>
+</nav>
+<div class="container mt-5">
+  <div class="card-body">
+    <table data-toggle="table" data-search="true" data-show-columns="true" data-pagination="true" id="table">
+      <thead>
+        <tr>
+          <th data-valign="middle" class="text-center" data-sortable="true">#</th>
+          <th data-valign="middle" class="text-center">商品照片</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">名稱</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">售價</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">庫存</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">發售狀態</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">上架狀態</th>
+          <th data-valign="middle" class="text-center">商品操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each products}}
           <tr>
-            <th data-valign="middle" class="text-center" data-sortable="true">#</th>
-            <th data-valign="middle" class="text-center">商品照片</th>
-            <th data-valign="middle" class="text-center" data-sortable="true">名稱</th>
-            <th data-valign="middle" class="text-center" data-sortable="true">售價</th>
-            <th data-valign="middle" class="text-center" data-sortable="true">庫存</th>
-            <th data-valign="middle" class="text-center" data-sortable="true">模型分類</th>
-            <th data-valign="middle" class="text-center" data-sortable="true">作品分類</th>
-            <th data-valign="middle" class="text-center" data-sortable="true">發售狀態</th>
-            <th data-valign="middle" class="text-center" data-sortable="true">上架狀態</th>
-            <th data-valign="middle" class="text-center">商品操作</th>
+            <td>{{this.id}}</td>
+            <td>
+              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+                <img src="{{this.mainImg}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
+                  style="height:50px">
+              </a>
+            </td>
+            <td>
+              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+                {{this.name}}
+              </a>
+            </td>
+            <td>{{this.price}}</td>
+            <td>{{this.inventory}}</td>
+            <td>{{this.Category.name}}</td>
+            <td>{{this.Series.name}}</td>
+            <td>{{this.saleStatus}}</td>
+            <td>
+              {{#if this.status}}
+                <form action="/admin/products/{{this.id}}/undisplay" method="POST">
+                  <input type="text" name="id" hidden>
+                  <button type="submit" class="btn" title="將此商品下架"><i class="far fa-circle text-success"></i></button>
+                </form>
+              {{else}}
+                <form action="/admin/products/{{this.id}}/display" method="POST">
+                  <input type="text" name="id" hidden>
+                  <button type="submit" class="btn" title="將此商品上架"><i class="fas fa-times text-danger"></i>
+                  </button>
+                </form>
+              {{/if}}
+            </td>
+            <td>
+              <button type="button" class="btn font-weight-normal">
+                <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark "><i
+                    class="fas fa-edit" title="編輯此商品"></i></a>
+              </button>
+              <button type="button" class="btn font-weight-normal">
+                <a href="/admin/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark ">
+                  <i class="fas fa-search-plus" title="商品詳情"></i>
+                </a>
+              </button>
+              <!-- Delete Button trigger modal -->
+              <button type="button" class="btn font-weight-normal" data-toggle="modal" data-target="#delete_{{this.id}}"
+                title="刪除此商品">
+                <i class="far fa-trash-alt" aria-hidden="true"></i>
+              </button>
+            </td>
           </tr>
-          {{!-- <tr>
-            <th class="text-center" data-sortable="true">上架狀態</th>
-            <th class="text-center">編輯商品</th>
-            <th class="text-center">詳細資訊</th>
-            <th class="text-center">刪除商品</th>
-          </tr> --}}
-        </thead>
-        <tbody>
-          {{#each products}}
-            <tr>
-              <td>{{this.id}}</td>
-              <td>
-                <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
-                  <img src="{{this.imageUrl}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
-                    style="height:50px">
-                </a>
-              </td>
-              <td>
-                <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
-                  {{this.name}}
-                </a>
-              </td>
-              <td>{{this.price}}</td>
-              <td>{{this.inventory}}</td>
-              <td>{{this.Category.name}}</td>
-              <td>{{this.Series.name}}</td>
-              <td>{{this.saleStatus}}</td>
-              <td>
-                {{#if this.status}}
-                  <form action="/admin/products/{{this.id}}/undisplay" method="POST">
-                    <input type="text" name="id" hidden>
-                    <button type="submit" class="btn" title="將此商品下架"><i
-                        class="far fa-circle text-success"></br>上架中</i></button>
-                  </form>
-                {{else}}
-                  <form action="/admin/products/{{this.id}}/display" method="POST">
-                    <input type="text" name="id" hidden>
-                    <button type="submit" class="btn" title="將此商品上架"><i class="fas fa-times text-danger"></br>未上架</i>
+          {{!-- Delete modal --}}
+          <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
+            aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                </div>
+                <div class="modal-body">
+                  <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                    {{this.name}}</h5>
+                  </br>
+                  <h5 class="text-danger text-right">你真的要刪除這項商品嗎？</h5>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+                  <form action="/admin/products/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                    <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
                     </button>
                   </form>
-                {{/if}}
-              </td>
-              <td>
-                <button type="button" class="btn font-weight-normal">
-                  <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark "><i
-                      class="fas fa-edit" title="編輯此商品"></i></a>
-                </button>
-                <button type="button" class="btn font-weight-normal">
-                  <a href="/admin/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark ">
-                    <i class="fas fa-search-plus" title="商品詳情"></i>
-                  </a>
-                </button>
-                <!-- Delete Button trigger modal -->
-                <button type="button" class="btn font-weight-normal" data-toggle="modal"
-                  data-target="#delete_{{this.id}}" title="刪除此商品">
-                  <i class="far fa-trash-alt" aria-hidden="true"></i>
-                </button>
-              </td>
-            </tr>
-            {{!-- Delete modal --}}
-            <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
-              aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
-              <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                      <span aria-hidden="true">&times;</span>
-                    </button>
-                  </div>
-                  <div class="modal-body">
-                    <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
-                      {{this.name}}</h5>
-                    </br>
-                    <h5 class="text-danger text-right">你真的要刪除這項商品嗎？</h5>
-                  </div>
-                  <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
-                    <form action="/admin/products/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
-                      <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
-                      </button>
-                    </form>
-                  </div>
                 </div>
               </div>
             </div>
-          {{/each}}
-        </tbody>
-      </table>
-    </div>
+          </div>
+        {{/each}}
+      </tbody>
+    </table>
   </div>
 </div>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -55,7 +55,10 @@
               <i class="fas fa-times text-danger"></i>
             {{/if}}
           </td>
-          <td></td>
+          <td>
+            <a href="/admin/products/{{this.id}}" class="text-decoration-none text-dark d-block"><i
+                class="fas fa-edit"></i></a>
+          </td>
           <td>
             <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block"><i
                 class="fas fa-external-link-alt"></i></a>

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <!-- included style -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.1/css/all.min.css">
+  <link href="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/main.css">
+  {{#if css}}
+    <link rel="stylesheet" href="/css/{{css}}.css">
+  {{/if}}
+  <title>GreatSmile Online Shop</title>
+</head>
+
+<body>
+  {{{body}}}
+  <!-- included script -->
+  <import>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+      crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+      crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+      crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.js"></script>
+  </import>
+</body>
+
+</html>


### PR DESCRIPTION
<img width="1440" alt="螢幕快照 2019-12-22 下午7 06 51" src="https://user-images.githubusercontent.com/49901777/71321021-a2c72d00-24ee-11ea-9399-1295e6e41edf.png">

`GET /admin/products`頁面實作

## 手動測試目標
- 管理者登入後可以直接進到`/admin/products`商品總覽頁面
- 頁面各欄位可以進行排序
- search bar可以針對欄位進行關鍵字搜尋
- 點擊商品照片或名稱可以另開分頁連至前台該商品詳細頁面
- 若商品沒有圖片會顯示no image圖示
- 發售狀態以當日做邏輯判斷顯示是否已發售
- 上架欄位會依照狀態顯示O或X
- 上架欄位會因狀態切換表單路由`POST /admin/products/:id/display`或`POST /admin/products/:id/undisplay`
- 編輯商品圖示會連至`/admin/products/:id/edit`
- 詳細資訊圖示會連至`/admin/products/:id`
- 刪除圖示會觸發modal確認是否刪除該商品(刪除功能尚未實作)
- 分頁功能可依照不同排序/搜尋顯示

## 其他
- 後台似乎不需要前台的main layout，待討論
- 商品的相關屬性很多，全部列出畫面會很擁擠(現在也是)，看有沒有其他建議？
