### PR TITLE
【加入】排序功能

### DIFF
--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -31,7 +31,12 @@ module.exports = {
 
       const selectSort = sort ? `${sort}${foo}` : 'releaseDate'
 
-      return res.render('products', { products, selectSort, css: 'products' })
+      return res.render('products', { 
+        js: 'products',
+        css: 'products',
+        products,
+        selectSort 
+      })
 
     } catch (err) {
       console.error(err)

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -25,6 +25,9 @@ module.exports = {
       const sort = req.query.sort
       const order = req.query.order
       const showProducts = products.sort((a, b) => {
+        if (!order && !sort) {      // 還未選擇排序時，預設介紹日排序
+          return b.releaseDate - a.releaseDate
+        }
         if (order === 'asc') {      // 升冪排列，價格低至高
           return a[sort] - b[sort]
         }

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -31,7 +31,8 @@ module.exports = {
         return b[sort] - a[sort]
       })
 
-      return res.render('products', { showProducts, css: 'products' })
+      const selectSort = order ? `sort=${sort}&order=${order}` : `sort=${sort}`
+      return res.render('products', { showProducts, selectSort, css: 'products' })
 
     } catch (err) {
       console.error(err)

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -9,7 +9,6 @@ module.exports = {
     try {
       const products = await Product.findAll({
         include: ['Images', 'Gifts'],
-        order: [['saleDate', 'DESC']],
         where: { status: 1 }
       })
 
@@ -22,7 +21,17 @@ module.exports = {
         product.hasInv = (product.inventory !== 0)
       })
 
-      return res.render('products', { products, css: 'products' })
+      // select 排序
+      const sort = req.query.sort
+      const order = req.query.order
+      const showProducts = products.sort((a, b) => {
+        if (order === 'asc') {      // 升冪排列，價格低至高
+          return a[sort] - b[sort]
+        }
+        return b[sort] - a[sort]
+      })
+
+      return res.render('products', { showProducts, css: 'products' })
 
     } catch (err) {
       console.error(err)

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -7,10 +7,10 @@ moment.locale('zh-tw')
 module.exports = {
   getProducts: async (req, res) => {
     try {
-      // 排序條件
-      const sort = req.query.sort
-      const foo = req.query.order ? req.query.order : 'DESC'
-      const order = sort ? [[sort, foo]] : [['releaseDate', foo]]
+      // 排序條件，預設為 ['releaseDate', 'DESC']
+      const sort = req.query.sort || 'releaseDate'
+      const orderBy = req.query.order || 'DESC'
+      const order = [[sort, orderBy]]
 
       // db Query
       const products = await Product.findAll({
@@ -29,13 +29,13 @@ module.exports = {
         product.hasInv = (product.inventory !== 0)
       })
 
-      const selectSort = sort ? `${sort}${foo}` : 'releaseDate'
+      const selectedSort = `${sort},${orderBy}`
 
-      return res.render('products', { 
+      res.render('products', { 
         js: 'products',
         css: 'products',
         products,
-        selectSort 
+        selectedSort 
       })
 
     } catch (err) {

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -1,0 +1,8 @@
+// 排序 <select>
+$('#order').on('change', function() {
+  const selectValue = this.value
+  const [sort, order] = selectValue.split(',')
+  const queryString = `?sort=${sort}&order=${order}`
+
+  window.location = queryString
+})

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -1,5 +1,5 @@
 // 排序 <select>
-$('#order').on('change', function() {
+$('#sort').on('change', function() {
   const selectValue = this.value
   const [sort, order] = selectValue.split(',')
   const queryString = `?sort=${sort}&order=${order}`

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -50,5 +50,8 @@
       integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
   </import>
   <script src="/js/main.js"></script>
+  {{#if js}}
+    <script src="/js/{{js}}.js"></script>
+  {{/if}}
 </body>
 </html>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -184,7 +184,7 @@
             <span>{{product.saleDateFormat}}</span>
           </li>
           <li class="list-group-item">
-            <span class="mr-5">公告日</span>
+            <span class="mr-5">公開日</span>
             <span>{{product.releaseDateFormat}}</span>
           </li>
           <li class="list-group-item">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -46,24 +46,24 @@
         </div>
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
-            <select class="form-control" id="exampleFormControlSelect1" onchange="location = this.value;">
+            <select id="order" class="form-control">
               <option 
-                value="?sort=releaseDate"
-                {{#ifEqual selectSort 'releaseDateDESC'}}selected="selected"{{/ifEqual}}
+                value="releaseDate,DESC"
+                {{#ifEqual selectSort 'releaseDateDESC'}}selected{{/ifEqual}}
               >介紹日 新→舊</option>
               <option 
-                value="?sort=saleDate"
-                {{#ifEqual selectSort 'saleDateDESC'}}selected="selected"{{/ifEqual}}
+                value="saleDate,DESC"
+                {{#ifEqual selectSort 'saleDateDESC'}}selected{{/ifEqual}}
               >發售日 新→舊</option>
               <option 
-                value="?sort=price&order=ASC"
-                {{#ifEqual selectSort 'priceASC'}}selected="selected"{{/ifEqual}}
+                value="price,ASC"
+                {{#ifEqual selectSort 'priceASC'}}selected{{/ifEqual}}
               >
                 價格 低→高
               </option>
               <option 
-                value="?sort=price&order=DESC"
-                {{#ifEqual selectSort 'priceDESC'}}selected="selected"{{/ifEqual}}
+                value="price,DESC"
+                {{#ifEqual selectSort 'priceDESC'}}selected{{/ifEqual}}
               >
                 價格 高→低
               </option>

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -50,19 +50,19 @@
               <option 
                 value="releaseDate,DESC"
                 {{#ifEqual selectedSort 'releaseDate,DESC'}}selected{{/ifEqual}}
-              >介紹日 新→舊</option>
+              >最新公開</option>
               <option 
                 value="saleDate,DESC"
                 {{#ifEqual selectedSort 'saleDate,DESC'}}selected{{/ifEqual}}
-              >發售日 新→舊</option>
+              >最新發售</option>
               <option 
                 value="price,ASC"
                 {{#ifEqual selectedSort 'price,ASC'}}selected{{/ifEqual}}
-              >價格 低→高</option>
+              >價格低</option>
               <option 
                 value="price,DESC"
                 {{#ifEqual selectedSort 'price,DESC'}}selected{{/ifEqual}}
-              >價格 高→低</option>
+              >價格高</option>
             </select>
           </div>
           <a href="#" class="btn btn-display">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -47,20 +47,24 @@
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
             <select class="form-control" id="exampleFormControlSelect1" onchange="location = this.value;">
-              <option value="?sort=releaseDate"
-              {{#ifEqual selectSort 'sort=releaseDate'}}selected="selected"{{/ifEqual}}>
-                介紹日 新→舊
-              </option>
-              <option value="?sort=saleDate" 
-              {{#ifEqual selectSort 'sort=saleDate'}}selected="selected"{{/ifEqual}}>
-                發售日 新→舊
-              </option>
-              <option value="?sort=price&order=asc"
-              {{#ifEqual selectSort 'sort=price&order=asc'}}selected="selected"{{/ifEqual}}>
+              <option 
+                value="?sort=releaseDate"
+                {{#ifEqual selectSort 'releaseDateDESC'}}selected="selected"{{/ifEqual}}
+              >介紹日 新→舊</option>
+              <option 
+                value="?sort=saleDate"
+                {{#ifEqual selectSort 'saleDateDESC'}}selected="selected"{{/ifEqual}}
+              >發售日 新→舊</option>
+              <option 
+                value="?sort=price&order=ASC"
+                {{#ifEqual selectSort 'priceASC'}}selected="selected"{{/ifEqual}}
+              >
                 價格 低→高
               </option>
-              <option value="?sort=price&order=desc"
-              {{#ifEqual selectSort 'sort=price&order=desc'}}selected="selected"{{/ifEqual}}>
+              <option 
+                value="?sort=price&order=DESC"
+                {{#ifEqual selectSort 'priceDESC'}}selected="selected"{{/ifEqual}}
+              >
                 價格 高→低
               </option>
             </select>
@@ -75,7 +79,7 @@
       </div>
       {{!-- 商品型錄 --}}
       <div class="row">
-        {{#each showProducts}}
+        {{#each products}}
         <div class="col-md-2-5 mb-3">
           <div class="card">
             <div class="card-body">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -46,11 +46,11 @@
         </div>
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
-            <select class="form-control" id="exampleFormControlSelect1">
-              <option>發售日 新→舊</option>
-              <option>發售日 舊→新</option>
-              <option>價格 低→高</option>
-              <option>價格 高→低</option>
+            <select class="form-control" id="exampleFormControlSelect1" onchange="location = this.value;">
+              <option value="?sort=releaseDate">介紹日 新→舊</option>
+              <option value="?sort=saleDate">發售日 新→舊</option>
+              <option value="?sort=price&order=asc">價格 低→高</option>
+              <option value="?sort=price&order=desc">價格 高→低</option>
             </select>
           </div>
           <a href="#" class="btn btn-display">
@@ -63,7 +63,7 @@
       </div>
       {{!-- 商品型錄 --}}
       <div class="row">
-        {{#each products}}
+        {{#each showProducts}}
         <div class="col-md-2-5 mb-3">
           <div class="card">
             <div class="card-body">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -46,27 +46,23 @@
         </div>
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
-            <select id="order" class="form-control">
+            <select id="sort" class="form-control">
               <option 
                 value="releaseDate,DESC"
-                {{#ifEqual selectSort 'releaseDateDESC'}}selected{{/ifEqual}}
+                {{#ifEqual selectedSort 'releaseDate,DESC'}}selected{{/ifEqual}}
               >介紹日 新→舊</option>
               <option 
                 value="saleDate,DESC"
-                {{#ifEqual selectSort 'saleDateDESC'}}selected{{/ifEqual}}
+                {{#ifEqual selectedSort 'saleDate,DESC'}}selected{{/ifEqual}}
               >發售日 新→舊</option>
               <option 
                 value="price,ASC"
-                {{#ifEqual selectSort 'priceASC'}}selected{{/ifEqual}}
-              >
-                價格 低→高
-              </option>
+                {{#ifEqual selectedSort 'price,ASC'}}selected{{/ifEqual}}
+              >價格 低→高</option>
               <option 
                 value="price,DESC"
-                {{#ifEqual selectSort 'priceDESC'}}selected{{/ifEqual}}
-              >
-                價格 高→低
-              </option>
+                {{#ifEqual selectedSort 'price,DESC'}}selected{{/ifEqual}}
+              >價格 高→低</option>
             </select>
           </div>
           <a href="#" class="btn btn-display">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -47,10 +47,22 @@
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
             <select class="form-control" id="exampleFormControlSelect1" onchange="location = this.value;">
-              <option value="?sort=releaseDate">介紹日 新→舊</option>
-              <option value="?sort=saleDate">發售日 新→舊</option>
-              <option value="?sort=price&order=asc">價格 低→高</option>
-              <option value="?sort=price&order=desc">價格 高→低</option>
+              <option value="?sort=releaseDate"
+              {{#ifEqual selectSort 'sort=releaseDate'}}selected="selected"{{/ifEqual}}>
+                介紹日 新→舊
+              </option>
+              <option value="?sort=saleDate" 
+              {{#ifEqual selectSort 'sort=saleDate'}}selected="selected"{{/ifEqual}}>
+                發售日 新→舊
+              </option>
+              <option value="?sort=price&order=asc"
+              {{#ifEqual selectSort 'sort=price&order=asc'}}selected="selected"{{/ifEqual}}>
+                價格 低→高
+              </option>
+              <option value="?sort=price&order=desc"
+              {{#ifEqual selectSort 'sort=price&order=desc'}}selected="selected"{{/ifEqual}}>
+                價格 高→低
+              </option>
             </select>
           </div>
           <a href="#" class="btn btn-display">


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/50958992/71325698-3e768e80-252b-11ea-868a-99c296eedbbf.png" width=600>

- 所有商品頁加入排序功能
  - 介紹日 新→舊
  - 發售日 新→舊
  - 價格 低→高
  - 價格 高→低
- 未選擇排序時，依照「介紹日 新→舊」排序

## 確認目標
 進入所有商品頁 `/products` ，商品依照**介紹日新至舊**排序
- 點選 介紹日 新→舊
  - 商品依照**介紹日新至舊**排序
  - 下拉選單顯示「介紹日 新→舊」
- 點選 發售日 新→舊
  - 商品依照**發售日新至舊**排序
  - 下拉選單顯示「發售日 新→舊」
- 點選 價格 低→高
  - 商品依照**價格低至高**排序
  - 下拉選單顯示「價格 低→高」
- 點選 價格 高→低
  - 商品依照**價格高至低**排序
  - 下拉選單顯示「價格 高→低」