### PR TITLE
【加入】search 功能

### DIFF
--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -47,7 +47,8 @@ module.exports = {
         js: 'products',
         css: 'products',
         products,
-        selectedSort
+        selectedSort,
+        searchQuery
       })
 
     } catch (err) {

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -31,7 +31,12 @@ module.exports = {
 
       const selectSort = sort ? `${sort}${foo}` : 'releaseDate'
 
-      return res.render('products', { products, selectSort, css: 'products' })
+      return res.render('products', { 
+        js: 'products',
+        css: 'products',
+        products,
+        selectSort 
+      })
 
     } catch (err) {
       console.error(err)

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -25,6 +25,9 @@ module.exports = {
       const sort = req.query.sort
       const order = req.query.order
       const showProducts = products.sort((a, b) => {
+        if (!order && !sort) {      // 還未選擇排序時，預設介紹日排序
+          return b.releaseDate - a.releaseDate
+        }
         if (order === 'asc') {      // 升冪排列，價格低至高
           return a[sort] - b[sort]
         }

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -42,13 +42,12 @@ module.exports = {
       })
 
       const selectedSort = `${sort},${orderBy}`
+      const bread = req.path.includes('search') ? '搜尋商品' : '製品一覽'
 
       res.render('products', { 
         js: 'products',
         css: 'products',
-        products,
-        selectedSort,
-        searchQuery
+        products, selectedSort, searchQuery, bread
       })
 
     } catch (err) {

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -31,7 +31,8 @@ module.exports = {
         return b[sort] - a[sort]
       })
 
-      return res.render('products', { showProducts, css: 'products' })
+      const selectSort = order ? `sort=${sort}&order=${order}` : `sort=${sort}`
+      return res.render('products', { showProducts, selectSort, css: 'products' })
 
     } catch (err) {
       console.error(err)

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -9,7 +9,6 @@ module.exports = {
     try {
       const products = await Product.findAll({
         include: ['Images', 'Gifts'],
-        order: [['saleDate', 'DESC']],
         where: { status: 1 }
       })
 
@@ -22,7 +21,17 @@ module.exports = {
         product.hasInv = (product.inventory !== 0)
       })
 
-      return res.render('products', { products, css: 'products' })
+      // select 排序
+      const sort = req.query.sort
+      const order = req.query.order
+      const showProducts = products.sort((a, b) => {
+        if (order === 'asc') {      // 升冪排列，價格低至高
+          return a[sort] - b[sort]
+        }
+        return b[sort] - a[sort]
+      })
+
+      return res.render('products', { showProducts, css: 'products' })
 
     } catch (err) {
       console.error(err)

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -7,10 +7,10 @@ moment.locale('zh-tw')
 module.exports = {
   getProducts: async (req, res) => {
     try {
-      // 排序條件
-      const sort = req.query.sort
-      const foo = req.query.order ? req.query.order : 'DESC'
-      const order = sort ? [[sort, foo]] : [['releaseDate', foo]]
+      // 排序條件，預設為 ['releaseDate', 'DESC']
+      const sort = req.query.sort || 'releaseDate'
+      const orderBy = req.query.order || 'DESC'
+      const order = [[sort, orderBy]]
 
       // db Query
       const products = await Product.findAll({
@@ -29,13 +29,13 @@ module.exports = {
         product.hasInv = (product.inventory !== 0)
       })
 
-      const selectSort = sort ? `${sort}${foo}` : 'releaseDate'
+      const selectedSort = `${sort},${orderBy}`
 
-      return res.render('products', { 
+      res.render('products', { 
         js: 'products',
         css: 'products',
         products,
-        selectSort 
+        selectedSort 
       })
 
     } catch (err) {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,5 +1,8 @@
 body {
   background-color: #ebebeb;
+  display: flex;
+  flex-flow: column;
+  min-height: 100vh;
 }
 
 .btn-top-bar {

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -1,0 +1,8 @@
+// 排序 <select>
+$('#order').on('change', function() {
+  const selectValue = this.value
+  const [sort, order] = selectValue.split(',')
+  const queryString = `?sort=${sort}&order=${order}`
+
+  window.location = queryString
+})

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -1,8 +1,15 @@
 // 排序 <select>
 $('#sort').on('change', function() {
-  const selectValue = this.value
-  const [sort, order] = selectValue.split(',')
-  const queryString = `?sort=${sort}&order=${order}`
+  // 取得 selected 排序
+  const selectedValue = this.value
+  const [sort, order] = selectedValue.split(',')
+  let queryString = `?sort=${sort}&order=${order}`
+  
+  // 確認 search query
+  const searchQuery = $('#searchQuery').data('q')
+  if (searchQuery) {
+    queryString = `?q=${searchQuery}&sort=${sort}&order=${order}` 
+  } 
 
   window.location = queryString
 })

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -1,5 +1,5 @@
 // 排序 <select>
-$('#order').on('change', function() {
+$('#sort').on('change', function() {
   const selectValue = this.value
   const [sort, order] = selectValue.split(',')
   const queryString = `?sort=${sort}&order=${order}`

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,7 +7,7 @@ const userCtrller = require('../controllers/userCtrller')
 
 
 module.exports = (app, passport) => {
-  app.get('/', (req, res) => res.send('home page'))
+  app.get('/', (req, res) => res.render('home'))
 
   app.use('/products', require('./products.js'))
   app.use('/users', require('./users.js'))

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,6 +13,8 @@ module.exports = (app, passport) => {
   app.use('/users', require('./users.js'))
   app.use('/admin', require('./admin/admin.js'))
 
+  app.get('/search', require('../controllers/prodCtrller').getProducts)
+
   // user account
   app.get('/signup', userCtrller.getSignUp)
   app.post('/signup', userCtrller.signUp)

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -1,0 +1,1 @@
+<h1>home page</h1>

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -18,7 +18,7 @@
 <body>
   {{> header}}
   {{{body}}}
-  <footer class="container-fluid py-3 text-center">
+  <footer class="w-100 mt-auto py-3 text-center">
     <a href="jquery:;" class="back-top">
       <i class="fas fa-chevron-up"></i>
     </a>

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -50,5 +50,8 @@
       integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
   </import>
   <script src="/js/main.js"></script>
+  {{#if js}}
+    <script src="/js/{{js}}.js"></script>
+  {{/if}}
 </body>
 </html>

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -34,7 +34,7 @@
       <div class="col-md-12 ">
         <form action="/search" method="GET">
           <div class="input-group">
-            <input type="text" name="query" class="form-control search-input" placeholder="搜尋商品">
+            <input type="text" name="q" class="form-control search-input" placeholder="搜尋商品">
             <div class="input-group-append">
               <button class="btn btn-orange">
                 <i class="fas fa-search px-2"></i>

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -34,7 +34,7 @@
       <div class="col-md-12 ">
         <form action="/search" method="GET">
           <div class="input-group">
-            <input type="text" name="q" class="form-control search-input" placeholder="搜尋商品">
+            <input type="text" name="q" class="form-control search-input" placeholder="搜尋商品" value="{{searchQuery}}">
             <div class="input-group-append">
               <button class="btn btn-orange">
                 <i class="fas fa-search px-2"></i>

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-light p-0">
   <div class="w-100 bg-white">
     <div class="container py-3">
-      <a class="navbar-brand">LOGO</a>
+      <a href="/" class="navbar-brand">LOGO</a>
       <div>
         <a class="btn btn-primary mr-2 btn-top-bar" href="/signin">登入·註冊</a>
         <a class="btn btn-primary btn-top-bar" href="/cart">購物車</a>

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -32,15 +32,16 @@
   <div class="container-fluid py-2 search-bar">
     <div class="row mx-auto">
       <div class="col-md-12 ">
-        <div class="input-group">
-          <input type="text" class="form-control search-input" placeholder="Recipient's username" aria-label="Recipient's username"
-            aria-describedby="button-addon2">
-          <div class="input-group-append">
-            <button class="btn btn-outline-secondary btn-orange" type="button" id="button-addon2">
-              <i class="fas fa-search px-2"></i>
-            </button>
+        <form action="/search" method="GET">
+          <div class="input-group">
+            <input type="text" name="query" class="form-control search-input" placeholder="搜尋商品">
+            <div class="input-group-append">
+              <button class="btn btn-orange">
+                <i class="fas fa-search px-2"></i>
+              </button>
+            </div>
           </div>
-        </div>
+        </form>
       </div>
     </div>
   </div>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -184,7 +184,7 @@
             <span>{{product.saleDateFormat}}</span>
           </li>
           <li class="list-group-item">
-            <span class="mr-5">公告日</span>
+            <span class="mr-5">公開日</span>
             <span>{{product.releaseDateFormat}}</span>
           </li>
           <li class="list-group-item">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -46,24 +46,24 @@
         </div>
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
-            <select class="form-control" id="exampleFormControlSelect1" onchange="location = this.value;">
+            <select id="order" class="form-control">
               <option 
-                value="?sort=releaseDate"
-                {{#ifEqual selectSort 'releaseDateDESC'}}selected="selected"{{/ifEqual}}
+                value="releaseDate,DESC"
+                {{#ifEqual selectSort 'releaseDateDESC'}}selected{{/ifEqual}}
               >介紹日 新→舊</option>
               <option 
-                value="?sort=saleDate"
-                {{#ifEqual selectSort 'saleDateDESC'}}selected="selected"{{/ifEqual}}
+                value="saleDate,DESC"
+                {{#ifEqual selectSort 'saleDateDESC'}}selected{{/ifEqual}}
               >發售日 新→舊</option>
               <option 
-                value="?sort=price&order=ASC"
-                {{#ifEqual selectSort 'priceASC'}}selected="selected"{{/ifEqual}}
+                value="price,ASC"
+                {{#ifEqual selectSort 'priceASC'}}selected{{/ifEqual}}
               >
                 價格 低→高
               </option>
               <option 
-                value="?sort=price&order=DESC"
-                {{#ifEqual selectSort 'priceDESC'}}selected="selected"{{/ifEqual}}
+                value="price,DESC"
+                {{#ifEqual selectSort 'priceDESC'}}selected{{/ifEqual}}
               >
                 價格 高→低
               </option>

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -50,19 +50,19 @@
               <option 
                 value="releaseDate,DESC"
                 {{#ifEqual selectedSort 'releaseDate,DESC'}}selected{{/ifEqual}}
-              >介紹日 新→舊</option>
+              >最新公開</option>
               <option 
                 value="saleDate,DESC"
                 {{#ifEqual selectedSort 'saleDate,DESC'}}selected{{/ifEqual}}
-              >發售日 新→舊</option>
+              >最新發售</option>
               <option 
                 value="price,ASC"
                 {{#ifEqual selectedSort 'price,ASC'}}selected{{/ifEqual}}
-              >價格 低→高</option>
+              >價格低</option>
               <option 
                 value="price,DESC"
                 {{#ifEqual selectedSort 'price,DESC'}}selected{{/ifEqual}}
-              >價格 高→低</option>
+              >價格高</option>
             </select>
           </div>
           <a href="#" class="btn btn-display">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -47,20 +47,24 @@
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
             <select class="form-control" id="exampleFormControlSelect1" onchange="location = this.value;">
-              <option value="?sort=releaseDate"
-              {{#ifEqual selectSort 'sort=releaseDate'}}selected="selected"{{/ifEqual}}>
-                介紹日 新→舊
-              </option>
-              <option value="?sort=saleDate" 
-              {{#ifEqual selectSort 'sort=saleDate'}}selected="selected"{{/ifEqual}}>
-                發售日 新→舊
-              </option>
-              <option value="?sort=price&order=asc"
-              {{#ifEqual selectSort 'sort=price&order=asc'}}selected="selected"{{/ifEqual}}>
+              <option 
+                value="?sort=releaseDate"
+                {{#ifEqual selectSort 'releaseDateDESC'}}selected="selected"{{/ifEqual}}
+              >介紹日 新→舊</option>
+              <option 
+                value="?sort=saleDate"
+                {{#ifEqual selectSort 'saleDateDESC'}}selected="selected"{{/ifEqual}}
+              >發售日 新→舊</option>
+              <option 
+                value="?sort=price&order=ASC"
+                {{#ifEqual selectSort 'priceASC'}}selected="selected"{{/ifEqual}}
+              >
                 價格 低→高
               </option>
-              <option value="?sort=price&order=desc"
-              {{#ifEqual selectSort 'sort=price&order=desc'}}selected="selected"{{/ifEqual}}>
+              <option 
+                value="?sort=price&order=DESC"
+                {{#ifEqual selectSort 'priceDESC'}}selected="selected"{{/ifEqual}}
+              >
                 價格 高→低
               </option>
             </select>
@@ -75,7 +79,7 @@
       </div>
       {{!-- 商品型錄 --}}
       <div class="row">
-        {{#each showProducts}}
+        {{#each products}}
         <div class="col-md-2-5 mb-3">
           <div class="card">
             <div class="card-body">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -46,11 +46,11 @@
         </div>
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
-            <select class="form-control" id="exampleFormControlSelect1">
-              <option>發售日 新→舊</option>
-              <option>發售日 舊→新</option>
-              <option>價格 低→高</option>
-              <option>價格 高→低</option>
+            <select class="form-control" id="exampleFormControlSelect1" onchange="location = this.value;">
+              <option value="?sort=releaseDate">介紹日 新→舊</option>
+              <option value="?sort=saleDate">發售日 新→舊</option>
+              <option value="?sort=price&order=asc">價格 低→高</option>
+              <option value="?sort=price&order=desc">價格 高→低</option>
             </select>
           </div>
           <a href="#" class="btn btn-display">
@@ -63,7 +63,7 @@
       </div>
       {{!-- 商品型錄 --}}
       <div class="row">
-        {{#each products}}
+        {{#each showProducts}}
         <div class="col-md-2-5 mb-3">
           <div class="card">
             <div class="card-body">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -4,139 +4,143 @@
       {{!-- 麵包屑 --}}
       <nav class="bread mb-3">
         <a href="/">Home </a>&gt;
-        <span>製品一覽</span>
+        <span>{{bread}}</span>
       </nav>
-      {{!-- 分頁 --}}
-      <div class="row">
-        <nav aria-label="Page navigation example">
-          <ul class="pagination">
-            <li class="page-item">
-              <a class="page-link" href="#">
-                <span aria-hidden="true">&laquo;</span>
-              </a>
-            </li>
-            <li class="page-item"><a class="page-link" href="#">1</a></li>
-            <li class="page-item"><a class="page-link" href="#">2</a></li>
-            <li class="page-item"><a class="page-link" href="#">3</a></li>
-            <li class="page-item">
-              <a class="page-link" href="#">
-                <span aria-hidden="true">&raquo;</span>
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-      {{!-- tag + select --}}
-      <div class="row d-flex justify-content-between">
-        <div class="d-flex align-items-start">
-          <ul class="nav-tag">
-            <li class="d-inline">
-              <a href="#" class="btn btn-sm">預購中</a>
-            </li>
-            <li class="d-inline">
-              <a href="#" class="btn btn-sm">特典</a>
-            </li>
-            <li class="d-inline">
-              <a href="#" class="btn btn-sm">庫存販售商品</a>
-            </li>
-            <li class="d-inline">
-              <a href="#" class="btn btn-sm active">所有商品</a>
-            </li>
-          </ul>
-        </div>
-        <div class="d-flex align-items-start">
-          <div class="form-group d-inline-block">
-            <div id="searchQuery" data-q="{{searchQuery}}" hidden></div>
-            <select id="sort" class="form-control">
-              <option 
-                value="releaseDate,DESC"
-                {{#ifEqual selectedSort 'releaseDate,DESC'}}selected{{/ifEqual}}
-              >最新公開</option>
-              <option 
-                value="saleDate,DESC"
-                {{#ifEqual selectedSort 'saleDate,DESC'}}selected{{/ifEqual}}
-              >最新發售</option>
-              <option 
-                value="price,ASC"
-                {{#ifEqual selectedSort 'price,ASC'}}selected{{/ifEqual}}
-              >價格低</option>
-              <option 
-                value="price,DESC"
-                {{#ifEqual selectedSort 'price,DESC'}}selected{{/ifEqual}}
-              >價格高</option>
-            </select>
-          </div>
-          <a href="#" class="btn btn-display">
-            <i class="fas fa-list"></i>
-          </a>
-          <a href="#" class="btn btn-display">
-            <i class="fas fa-th-large"></i>
-          </a>
-        </div>
-      </div>
-      {{!-- 商品型錄 --}}
-      <div class="row">
-        {{#each products}}
-        <div class="col-md-2-5 mb-3">
-          <div class="card">
-            <div class="card-body">
-              <div class="card-img-top card-bg mb-3">
-                <img src="{{this.mainImg}}" class="card-img-top img-fit">
-              </div>
-              {{#if hasInv}}
-                {{#if isPreorder}}
-                <span class="tag tag-preorder">預購中</span>
-                {{else}}
-                <span class="tag tag-preorder">發售中</span>
-                {{/if}}
-              {{else}}
-                <span class="tag tag-sold-out">已售完</span>
-              {{/if}}
-
-              
-              {{#if isGift}}
-              <span class="tag tag-gift">特典</span>
-              {{/if}}
-              <h5 class="card-title mt-3">{{this.name}}</h5>
-              <p class="card-text pt-3 d-flex justify-content-end">NTD {{this.priceFormat}}</p>
-            </div>
-            <div class="hover ">
-              <div class="icon-group">
-                <a href="/products/{{this.id}}" class="btn btn-icon px-2 py-2 mx-1 d-inline-block">
-                  <img src="/img/magnifying-glass.png">
+      {{#if products.length}}
+        {{!-- 分頁 --}}
+        <div class="row">
+          <nav aria-label="Page navigation example">
+            <ul class="pagination">
+              <li class="page-item">
+                <a class="page-link" href="#">
+                  <span aria-hidden="true">&laquo;</span>
                 </a>
-                <form action="/cart" method="POST" class="d-inline-block">
-                  <input type="hidden">
-                  <button type="submit" class="btn btn-icon px-2 py-2 mx-1">
-                    <img src="/img/cart.png">
-                  </button>
-                </form>
+              </li>
+              <li class="page-item"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item">
+                <a class="page-link" href="#">
+                  <span aria-hidden="true">&raquo;</span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+        {{!-- tag + select --}}
+        <div class="row d-flex justify-content-between">
+          <div class="d-flex align-items-start">
+            <ul class="nav-tag">
+              <li class="d-inline">
+                <a href="#" class="btn btn-sm">預購中</a>
+              </li>
+              <li class="d-inline">
+                <a href="#" class="btn btn-sm">特典</a>
+              </li>
+              <li class="d-inline">
+                <a href="#" class="btn btn-sm">庫存販售商品</a>
+              </li>
+              <li class="d-inline">
+                <a href="#" class="btn btn-sm active">所有商品</a>
+              </li>
+            </ul>
+          </div>
+          <div class="d-flex align-items-start">
+            <div class="form-group d-inline-block">
+              <div id="searchQuery" data-q="{{searchQuery}}" hidden></div>
+              <select id="sort" class="form-control">
+                <option 
+                  value="releaseDate,DESC"
+                  {{#ifEqual selectedSort 'releaseDate,DESC'}}selected{{/ifEqual}}
+                >最新公開</option>
+                <option 
+                  value="saleDate,DESC"
+                  {{#ifEqual selectedSort 'saleDate,DESC'}}selected{{/ifEqual}}
+                >最新發售</option>
+                <option 
+                  value="price,ASC"
+                  {{#ifEqual selectedSort 'price,ASC'}}selected{{/ifEqual}}
+                >價格低</option>
+                <option 
+                  value="price,DESC"
+                  {{#ifEqual selectedSort 'price,DESC'}}selected{{/ifEqual}}
+                >價格高</option>
+              </select>
+            </div>
+            <a href="#" class="btn btn-display">
+              <i class="fas fa-list"></i>
+            </a>
+            <a href="#" class="btn btn-display">
+              <i class="fas fa-th-large"></i>
+            </a>
+          </div>
+        </div>
+        {{!-- 商品型錄 --}}
+        <div class="row">
+          {{#each products}}
+          <div class="col-md-2-5 mb-3">
+            <div class="card">
+              <div class="card-body">
+                <div class="card-img-top card-bg mb-3">
+                  <img src="{{this.mainImg}}" class="card-img-top img-fit">
+                </div>
+                {{#if hasInv}}
+                  {{#if isPreorder}}
+                  <span class="tag tag-preorder">預購中</span>
+                  {{else}}
+                  <span class="tag tag-preorder">發售中</span>
+                  {{/if}}
+                {{else}}
+                  <span class="tag tag-sold-out">已售完</span>
+                {{/if}}
+
+                
+                {{#if isGift}}
+                <span class="tag tag-gift">特典</span>
+                {{/if}}
+                <h5 class="card-title mt-3">{{this.name}}</h5>
+                <p class="card-text pt-3 d-flex justify-content-end">NTD {{this.priceFormat}}</p>
+              </div>
+              <div class="hover ">
+                <div class="icon-group">
+                  <a href="/products/{{this.id}}" class="btn btn-icon px-2 py-2 mx-1 d-inline-block">
+                    <img src="/img/magnifying-glass.png">
+                  </a>
+                  <form action="/cart" method="POST" class="d-inline-block">
+                    <input type="hidden">
+                    <button type="submit" class="btn btn-icon px-2 py-2 mx-1">
+                      <img src="/img/cart.png">
+                    </button>
+                  </form>
+                </div>
               </div>
             </div>
           </div>
+          {{/each}}
         </div>
-        {{/each}}
-      </div>
-      {{!-- 分頁 --}}
-      <div class="row">
-        <nav aria-label="Page navigation example">
-          <ul class="pagination">
-            <li class="page-item">
-              <a class="page-link" href="#">
-                <span aria-hidden="true">&laquo;</span>
-              </a>
-            </li>
-            <li class="page-item"><a class="page-link" href="#">1</a></li>
-            <li class="page-item"><a class="page-link" href="#">2</a></li>
-            <li class="page-item"><a class="page-link" href="#">3</a></li>
-            <li class="page-item">
-              <a class="page-link" href="#">
-                <span aria-hidden="true">&raquo;</span>
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
+        {{!-- 分頁 --}}
+        <div class="row">
+          <nav aria-label="Page navigation example">
+            <ul class="pagination">
+              <li class="page-item">
+                <a class="page-link" href="#">
+                  <span aria-hidden="true">&laquo;</span>
+                </a>
+              </li>
+              <li class="page-item"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item">
+                <a class="page-link" href="#">
+                  <span aria-hidden="true">&raquo;</span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      {{else}}
+        <h6 class="font-weight-bold">沒有與搜尋結果相符合的商品。</h6>
+      {{/if}}
     </main>
   </div>
 </div>

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -46,27 +46,23 @@
         </div>
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
-            <select id="order" class="form-control">
+            <select id="sort" class="form-control">
               <option 
                 value="releaseDate,DESC"
-                {{#ifEqual selectSort 'releaseDateDESC'}}selected{{/ifEqual}}
+                {{#ifEqual selectedSort 'releaseDate,DESC'}}selected{{/ifEqual}}
               >介紹日 新→舊</option>
               <option 
                 value="saleDate,DESC"
-                {{#ifEqual selectSort 'saleDateDESC'}}selected{{/ifEqual}}
+                {{#ifEqual selectedSort 'saleDate,DESC'}}selected{{/ifEqual}}
               >發售日 新→舊</option>
               <option 
                 value="price,ASC"
-                {{#ifEqual selectSort 'priceASC'}}selected{{/ifEqual}}
-              >
-                價格 低→高
-              </option>
+                {{#ifEqual selectedSort 'price,ASC'}}selected{{/ifEqual}}
+              >價格 低→高</option>
               <option 
                 value="price,DESC"
-                {{#ifEqual selectSort 'priceDESC'}}selected{{/ifEqual}}
-              >
-                價格 高→低
-              </option>
+                {{#ifEqual selectedSort 'price,DESC'}}selected{{/ifEqual}}
+              >價格 高→低</option>
             </select>
           </div>
           <a href="#" class="btn btn-display">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -47,10 +47,22 @@
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
             <select class="form-control" id="exampleFormControlSelect1" onchange="location = this.value;">
-              <option value="?sort=releaseDate">介紹日 新→舊</option>
-              <option value="?sort=saleDate">發售日 新→舊</option>
-              <option value="?sort=price&order=asc">價格 低→高</option>
-              <option value="?sort=price&order=desc">價格 高→低</option>
+              <option value="?sort=releaseDate"
+              {{#ifEqual selectSort 'sort=releaseDate'}}selected="selected"{{/ifEqual}}>
+                介紹日 新→舊
+              </option>
+              <option value="?sort=saleDate" 
+              {{#ifEqual selectSort 'sort=saleDate'}}selected="selected"{{/ifEqual}}>
+                發售日 新→舊
+              </option>
+              <option value="?sort=price&order=asc"
+              {{#ifEqual selectSort 'sort=price&order=asc'}}selected="selected"{{/ifEqual}}>
+                價格 低→高
+              </option>
+              <option value="?sort=price&order=desc"
+              {{#ifEqual selectSort 'sort=price&order=desc'}}selected="selected"{{/ifEqual}}>
+                價格 高→低
+              </option>
             </select>
           </div>
           <a href="#" class="btn btn-display">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -46,6 +46,7 @@
         </div>
         <div class="d-flex align-items-start">
           <div class="form-group d-inline-block">
+            <div id="searchQuery" data-q="{{searchQuery}}" hidden></div>
             <select id="sort" class="form-control">
               <option 
                 value="releaseDate,DESC"


### PR DESCRIPTION
search 功能預期前台全頁面都會使用，
在每個 controller 都寫 search 的程式碼，不太科學。

故，開了個 `"/search"` 的路由，controller 與 products 共用 `getProducts`。
頁面也是共用 `products.hbs`

#### branch 內容
- 加入 search feature。
- 開通 route `GET /search`
- 為了方便操作，建立陽春首頁 home.hbs

<br>

## 確認目標
- 在任何頁面都能使用 search
  - 搜尋後，路由應該變為 `/search?q=內文`
  - 麵包屑變為 `Home > 搜尋商品`
- 搜尋後，會保留 input 值
- 可以透過商品名稱搜尋
  - 直接從資料庫複製 Product.name 搜尋測試
  - 可以搜尋到所有「包含」該關鍵字的商品 (模糊比對)
- 可以透過作品名稱搜尋
  - 直接從資料庫複製 Series.name 搜尋測試
  - 應為模糊比對
- 查無結果時
  - 頁面應該只會出現麵包屑跟提示文字
  - footer 應該置底
- 搜尋後，可以保持搜尋結果，進一步使用排序功能
  - 可以透過網址的 query string 確認排序與搜尋是否同時存在
  - 搜尋的 query string 比照 Youtube 與 Google 命名為 `q`