### PR TITLE
【加入】product 畫廊展示功能

### DIFF
--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -59,11 +59,15 @@ module.exports = {
   getProduct: async (req, res) => {
     try {
       const product = await Product.findByPk(+req.params.id, { 
-        include: ['Gifts', 'Images', 'tags', 'Series'] 
+        include: ['Gifts', 'Images', 'tags', 'Series'],
+        // 使 Images 第一張為 mainImg，之後依上傳順排序
+        order: [
+          ['Images', 'isMain', 'DESC'],
+          ['Images', 'id', 'ASC']
+        ]
       })
 
       // 頁面所需 data
-      product.mainImg = product.Images.find(img => img.isMain).url
       product.priceFormat = product.price.toLocaleString()
       product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
       product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -58,7 +58,9 @@ module.exports = {
 
   getProduct: async (req, res) => {
     try {
-      const product = await Product.findByPk(+req.params.id, { 
+      const product = await Product.findOne({ 
+        // 只取上架中商品
+        where: { 'id': +req.params.id, 'status': true },
         include: ['Gifts', 'Images', 'tags', 'Series'],
         // 使 Images 第一張為 mainImg，之後依上傳順排序
         order: [
@@ -66,6 +68,8 @@ module.exports = {
           ['Images', 'id', 'ASC']
         ]
       })
+      
+      if (!product) return res.redirect('/products')
 
       // 頁面所需 data
       product.priceFormat = product.price.toLocaleString()

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -72,7 +72,7 @@ module.exports = {
       product.isOnSale = moment(new Date).isAfter(product.deadline)
       product.hasInv = (product.inventory !== 0)
 
-      res.render('product', { css: 'product', product })
+      res.render('product', { css: 'product', js: 'product', product })
 
     } catch (err) {
       console.error(err)

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -17,31 +17,47 @@ section {
 }
 
 /* 圖片畫廊 */
-.prod-img {
-  width: 530px;
-  height: 670px;
+.slider-for {
+  max-width: 530px;
   margin: 0 auto;
-  background: #eee;
 }
 
-.arrow-btn {
-  font-size: 2rem;
-  cursor: pointer;
-}
-
-.img-list {
+.slider-nav {
   width: 500px;
-  overflow: hidden;
-  text-align: left;
+  margin: 0 auto;
 }
 
-.img-list img {
+.slider-nav img {
   width: 70px;
-  height: 70px;
+  height: 70px; 
 }
 
-.gallery {
-  width: 1000px;
+.slick-prev {
+  left: -45px;
+}
+
+.slick-next {
+  right: -32px;
+}
+
+.slick-prev:before, .slick-next:before {
+  font-size: 1.5rem;
+  background: #545b62;
+  color: #fff;
+  padding: 0.3rem 0.6rem;
+  border-radius: 5px;
+}
+
+.slick-prev:before {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  content: "\f053";
+}
+
+.slick-next:before {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  content: "\f054";
 }
 
 /* Tag 群 */

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -17,27 +17,29 @@ section {
 }
 
 /* 圖片畫廊 */
-.slider-for {
-  max-width: 530px;
+.gallery-main {
+  width: 530px;
+  height: 670px;
+  margin: 0 auto;
+  background: #eee;
+}
+
+.gallery-nav {
+  width: 90%;
   margin: 0 auto;
 }
 
-.slider-nav {
-  width: 500px;
-  margin: 0 auto;
-}
-
-.slider-nav img {
+.gallery-nav img {
   width: 70px;
   height: 70px; 
 }
 
 .slick-prev {
-  left: -45px;
+  left: -50px;
 }
 
 .slick-next {
-  right: -32px;
+  right: -37px;
 }
 
 .slick-prev:before, .slick-next:before {
@@ -58,6 +60,24 @@ section {
   font-family: "Font Awesome 5 Free";
   font-weight: 900;
   content: "\f054";
+}
+
+@media screen and (max-width: 1199.98px) {
+  .gallery-main {
+    width: 400px;
+    height: 506px;
+  }
+}
+
+@media screen and (max-width: 767.98px) {
+  .gallery-main {
+    width: 350px;
+    height: 442px;
+  }
+
+  .gallery-nav {
+    width: 100%;
+  }
 }
 
 /* Tag 群 */

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -2,6 +2,12 @@ p {
   margin: 0;
 }
 
+ol, ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 section {
   border-radius: 20px;
   background: #fff;
@@ -40,6 +46,14 @@ section {
 
 .slick-next {
   right: -37px;
+}
+
+.slick-slide a:focus {
+  outline: none
+}
+
+.gallery-nav .slick-current img {
+  border: 3px solid #ff9600;
 }
 
 .slick-prev:before, .slick-next:before {

--- a/public/js/product.js
+++ b/public/js/product.js
@@ -23,4 +23,9 @@ $(document).ready(function () {
       },
     ]
   })
+
+  lightbox.option({
+    'fitImagesInViewport': false,
+    'maxWidth': 720
+  })
 })

--- a/public/js/product.js
+++ b/public/js/product.js
@@ -1,19 +1,26 @@
 $(document).ready(function () {
-  $('.slider-for').slick({
+  $('.gallery-main').slick({
     slidesToShow: 1,
     slidesToScroll: 1,
     arrows: true,
     fade: true,
     infinite: false,
-    asNavFor: '.slider-nav'
+    asNavFor: '.gallery-nav'
   })
 
-  $('.slider-nav').slick({
+  $('.gallery-nav').slick({
     slidesToShow: 5.5,
-    slidesToScroll: 5,
     arrows: false,
-    asNavFor: '.slider-for',
     infinite: false,
-    focusOnSelect: true
+    focusOnSelect: true,
+    asNavFor: '.gallery-main',
+    responsive: [
+      {
+        breakpoint: 768,
+        settings: {
+          slidesToShow: 4.5,
+        }
+      },
+    ]
   })
 })

--- a/public/js/product.js
+++ b/public/js/product.js
@@ -1,0 +1,19 @@
+$(document).ready(function () {
+  $('.slider-for').slick({
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    arrows: true,
+    fade: true,
+    infinite: false,
+    asNavFor: '.slider-nav'
+  })
+
+  $('.slider-nav').slick({
+    slidesToShow: 5.5,
+    slidesToScroll: 5,
+    arrows: false,
+    asNavFor: '.slider-for',
+    infinite: false,
+    focusOnSelect: true
+  })
+})

--- a/seeders/20191218114425-image-seeder.js
+++ b/seeders/20191218114425-image-seeder.js
@@ -9,17 +9,17 @@ module.exports = {
   up: (queryInterface, Sequelize) => {
     return Promise.all([
       queryInterface.bulkInsert('Images',
-        Array.from({ length: 20 }, (val, index) => ({
-          url: faker.image.imageUrl(530, 670, 'cats'),
-          product_id: index + 1,
-          is_main: true
+        Array.from({ length: 60 }, (val, index) => ({
+          url: `https://picsum.photos/seed/${index + 1}/530/670`,
+          product_id: index < 6 ? 1 : randomNum(2, 20),
+          is_main: false
         }))
       ),
       queryInterface.bulkInsert('Images',
-        Array.from({ length: 60 }, (val, index) => ({
-          url: faker.image.imageUrl(530, 670),
-          product_id: index < 6 ? 1 : randomNum(2, 20),
-          is_main: false
+        Array.from({ length: 20 }, (val, index) => ({
+          url: `https://picsum.photos/seed/main${index + 1}/530/670`,
+          product_id: index + 1,
+          is_main: true
         }))
       )
     ])

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -9,6 +9,8 @@
     integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.1/css/all.min.css">
   <link href="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css">
   <link rel="stylesheet" href="/css/main.css">
   {{#if css}}
     <link rel="stylesheet" href="/css/{{css}}.css">
@@ -48,6 +50,7 @@
       integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
       integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    <script src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
   </import>
   <script src="/js/main.js"></script>
   {{#if js}}

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -11,6 +11,7 @@
   <link href="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.css" rel="stylesheet">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.1/css/lightbox.min.css">
   <link rel="stylesheet" href="/css/main.css">
   {{#if css}}
     <link rel="stylesheet" href="/css/{{css}}.css">
@@ -50,7 +51,8 @@
       integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
       integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-    <script src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.1/js/lightbox.min.js"></script>
   </import>
   <script src="/js/main.js"></script>
   {{#if js}}

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -10,24 +10,26 @@
     {{!-- 圖片區塊 --}}
     <div class="row pb-4">
       {{!-- 畫廊 --}}
-      <div class="col-md-8">
-        <div class="slider-for">
+      <div class="col-lg-8">
+        <div class="gallery-main">
           {{#each product.Images}}
             <div class="">
-              <img class="" src="{{url}}" alt="product-image">
+              <img class="w-100" src="{{url}}" alt="product-image">
             </div>
           {{/each}}
         </div>
-        <div class="slider-nav mt-4">
+        <ul class="gallery-nav mt-4">
           {{#each product.Images}}
-            <div>
-              <img src="{{url}}" alt="product-image-sm" class="img-thumbnail">
-            </div>
+            <li>
+              <a href="jquery:;">
+                <img src="{{url}}" alt="product-image-sm" class="img-thumbnail">
+              </a>
+            </li>
           {{/each}}
-        </div>
+        </ul>
       </div>
       {{!-- info、購物車 --}}
-      <div class="col-md-4">
+      <div class="col-lg-4 mt-lg-0 mt-sm-5">
         {{#if product.hasGift}}
           <div class="mb-3 pt-1">
             <span class="tag-icon mr-2">附特典</span>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -14,7 +14,9 @@
         <ul class="gallery-main">
           {{#each product.Images}}
             <li>
-              <img class="w-100" src="{{url}}" alt="product-image">
+              <a href="{{url}}" data-lightbox="images">
+                <img class="w-100" src="{{url}}" alt="product-image">
+              </a>
             </li>
           {{/each}}
         </ul>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -11,23 +11,19 @@
     <div class="row pb-4">
       {{!-- 畫廊 --}}
       <div class="col-md-8">
-        <div class="prod-img">
-          <img class="w-100" src="{{product.mainImg}}" alt="product-image">
-        </div>
-        <div class="mt-4 d-flex justify-content-center align-items-center">
-          <span class="arrow-btn">
-            <i class="fas fa-angle-left"></i>
-          </span>            
-          <div class="img-list mx-3">
-            <div class="d-inline-block gallery">
-              {{#each product.Images}}
-                <img src="{{url}}" alt="image-list" class="mr-3 img-thumbnail">
-              {{/each}}
+        <div class="slider-for">
+          {{#each product.Images}}
+            <div class="">
+              <img class="" src="{{url}}" alt="product-image">
             </div>
-          </div>
-          <span class="arrow-btn">
-            <i class="fas fa-angle-right"></i>
-          </span>
+          {{/each}}
+        </div>
+        <div class="slider-nav mt-4">
+          {{#each product.Images}}
+            <div>
+              <img src="{{url}}" alt="product-image-sm" class="img-thumbnail">
+            </div>
+          {{/each}}
         </div>
       </div>
       {{!-- info、購物車 --}}
@@ -44,7 +40,7 @@
         </div>
         <hr>
         <div class="small-text">
-          <form id="postCart" action="#" method="POST" class="h-100">
+          <form action="#" method="POST" class="h-100">
             <div class="form-group text-center">
               <button class="cart-btn cart-btn-lg btn"
                 {{#unless product.hasInv}}disabled{{/unless}}
@@ -135,7 +131,7 @@
       <div class="col-md-6">
         <small>NTD {{product.priceFormat}}</small>
         <div class="mt-2">
-          <form id="postCart" action="#" method="POST">
+          <form action="#" method="POST">
             <div class="form-group">
               <button class="cart-btn cart-btn-sm btn"
                 {{#unless product.hasInv}}disabled{{/unless}}

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -11,13 +11,13 @@
     <div class="row pb-4">
       {{!-- 畫廊 --}}
       <div class="col-lg-8">
-        <div class="gallery-main">
+        <ul class="gallery-main">
           {{#each product.Images}}
-            <div class="">
+            <li>
               <img class="w-100" src="{{url}}" alt="product-image">
-            </div>
+            </li>
           {{/each}}
-        </div>
+        </ul>
         <ul class="gallery-nav mt-4">
           {{#each product.Images}}
             <li>


### PR DESCRIPTION
商品詳細頁，加入畫廊展示與燈箱展示功能。

#### main.hbs 引入前端套件
- slick-carousel (畫廊)
- lightbox2 (燈箱)

<s>
目前假資料的圖片是對 lorempixel.com 用 url 打 API 要圖，
燈箱效果再開啟時會再發一次該 url，導致會生成不同的隨機圖片。
所以目前燈箱出現不同圖片，屬正常現象。
</s>

<br>

#### ※ 已更換假圖 API，圖片問題已解決，請參考下方回應

<br>

## 確認目標
- 有製作簡易 RWD，視窗縮小時，畫廊按鈕不會爆版。
- click 左 / 右 按鈕，可以切換圖片。
- 切換圖片時，下方的小圖片 list 能正確對應到大圖。
- 下方的圖片 list，會高亮顯示當前圖片。 (這不是原本套件的功能，研究了一陣子......)
- click 大圖可以開啟 lightbox，並能正常工作。
  - <s>如上述所提，不只圖片會隨機到別張，而且等 lorempixel 回應，會等超久......</s>

<s>
建議燈箱測試時，把 Image seeder 改一下，
把兩個 url 屬性值，改成指定圖片 id 跟 lorempixel 要圖。
重刷 seeder 之後再來測燈箱。
</s>

<pre>
<s>url: `http://lorempixel.com/530/670/cats/${index + 1}`
url: `http://lorempixel.com/530/670/food/${index + 1}`</s>
</pre>

<s>測完之後記得把 seeder 改回來，因為 lorempixel 實際有的圖片 id 好像沒那麼多。
這樣後面的其他商品，假圖會沒東西。</s>

#### ※ 已更換假圖 API，圖片問題已解決，請參考下方回應