### PR TITLE
【加入】後台商品頁CRUD功能

### DIFF
--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -97,7 +97,7 @@ module.exports = {
   postNewProduct: async (req, res) => {
     try {
       const input = { ...req.body }
-      console.log(input)
+      console.log(req)
       const product = {
         name: input.name,
         price: input.price,
@@ -125,6 +125,20 @@ module.exports = {
         }
         TagItem.create(tagItem)
       })
+
+      //寫入mainImage
+      const { file } = req
+      if (file) {
+        imgur.setClientId(IMGUR_CLIENT_ID)
+        const mainImg = {
+          url: (await imgur.uploadFile(file.path)).data.link,
+          ProductId: newProduct.id,
+          isMain: true
+        }
+        Image.create(mainImg)
+      }
+
+
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -42,6 +42,33 @@ module.exports = {
 
   getAddPage: (req, res) => {
     res.render('admin/new')
-  }
+  },
+
+  postDisplay: async (req, res) => {
+    try {
+      const productId = req.params.id
+      const product = await Product.findByPk(productId)
+      product.status = true
+      product.save().then(function () { })
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+    res.redirect('/admin/products')
+  },
+
+  postUndisplay: async (req, res) => {
+    try {
+      const productId = req.params.id
+      const product = await Product.findByPk(productId)
+      product.status = false
+      product.save().then(function () { })
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+    res.redirect('/admin/products')
+  },
+
 
 }

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -1,7 +1,8 @@
 const db = require('../../models')
-const { Product, Category, Series, Image } = db
-
+const { Product, Category, Series, Image, Tag } = db
 const moment = require('moment')
+const imgur = require('imgur')
+const IMGUR_CLIENT_ID = process.env.IMGUR_CLIENT_ID
 
 module.exports = {
   getProducts: async (req, res) => {
@@ -40,8 +41,20 @@ module.exports = {
     }
   },
 
-  getAddPage: (req, res) => {
-    res.render('admin/new', { css: 'adminAdd' })
+  getAddPage: async (req, res) => {
+    const [categories, series, tag] = await Promise.all([
+      Category.findAll({
+        order: [['id', 'ASC']],
+      }),
+      Series.findAll({
+        order: [['id', 'ASC']],
+      }),
+      Tag.findAll({
+        order: [['id', 'ASC']],
+      })
+    ])
+
+    res.render('admin/new', { categories, series, tag, css: 'adminAdd' })
   },
 
   postDisplay: async (req, res) => {
@@ -83,6 +96,8 @@ module.exports = {
 
   postNewProduct: async (req, res) => {
     try {
+      const input = { ...req.body }
+      console.log(input)
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -97,7 +97,7 @@ module.exports = {
   postNewProduct: async (req, res) => {
     try {
       const input = { ...req.body }
-      console.log(req)
+
       const product = {
         name: input.name,
         price: input.price,
@@ -126,19 +126,27 @@ module.exports = {
         TagItem.create(tagItem)
       })
 
-      //寫入mainImage
-      const { file } = req
-      if (file) {
-        imgur.setClientId(IMGUR_CLIENT_ID)
+      //寫入Image
+      const { files } = req
+      if (files) {
         const mainImg = {
-          url: (await imgur.uploadFile(file.path)).data.link,
+          url: (await imgur.uploadFile(files[0].path)).data.link,
           ProductId: newProduct.id,
           isMain: true
         }
         Image.create(mainImg)
+
+        //移除第一筆後全寫入
+        files.shift()
+        for (const file of files) {
+          const img = {
+            url: (await imgur.uploadFile(file.path)).data.link,
+            ProductId: newProduct.id,
+            isMain: false
+          }
+          Image.create(img)
+        }
       }
-
-
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -70,5 +70,15 @@ module.exports = {
     res.redirect('/admin/products')
   },
 
+  deleteProduct: async (req, res) => {
+    try {
+      const product = await Product.findByPk(req.params.id)
+      product.destroy()
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+    res.redirect('/admin/products')
+  },
 
 }

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -81,4 +81,14 @@ module.exports = {
     res.redirect('/admin/products')
   },
 
+  postNewProduct: async (req, res) => {
+    try {
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+    res.redirect('/admin/products')
+  }
+
 }

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -108,7 +108,7 @@ module.exports = {
         copyright: input.copyright,
         maker: input.copyright,
         status: input.status,
-        releaseDate: input.releseDate,
+        releaseDate: input.releaseDate,
         saleDate: input.saleDate,
         deadline: input.deadline,
         SeriesId: Number(input.seriesId),
@@ -153,6 +153,63 @@ module.exports = {
       res.status(500).json(err.toString())
     }
     res.redirect('/admin/products')
-  }
+  },
+
+  getEditPage: async (req, res) => {
+    try {
+      const id = req.params.id
+      const product = await Product.findByPk(id)
+      const releaseDate = product.releaseDate.toJSON().split('T')[0]
+      const saleDate = product.saleDate.toJSON().split('T')[0]
+      const deadline = product.deadline.toJSON().split('T')[0]
+
+      const [categories, series, tag] = await Promise.all([
+        Category.findAll({
+          order: [['id', 'ASC']],
+        }),
+        Series.findAll({
+          order: [['id', 'ASC']],
+        }),
+        Tag.findAll({
+          order: [['id', 'ASC']],
+        })
+      ])
+
+      const tagItem = await TagItem.findAll({
+        where: { product_id: id }
+      })
+
+      tag.forEach(tag => {
+        tagItem.forEach(tagItem => {
+          if (tag.id === tagItem.tag_id) {
+            tag.checked = true
+          }
+        })
+      })
+
+      const images = await Image.findAll({
+        where: { product_id: id },
+        order: [['id', 'ASC']]
+      })
+
+      console.log(images)
+
+      res.render('admin/edit', {
+        product,
+        categories,
+        series,
+        tag,
+        releaseDate,
+        saleDate,
+        deadline,
+        tagItem,
+        images,
+        css: 'adminAdd'
+      })
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
 
 }

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -98,6 +98,24 @@ module.exports = {
     try {
       const input = { ...req.body }
       console.log(input)
+      const product = {
+        name: input.name,
+        price: input.price,
+        inventory: input.inventory,
+        slogan: input.slogan,
+        description: input.description,
+        spec: input.spec,
+        copyright: input.copyright,
+        maker: input.copyright,
+        status: input.status,
+        releaseDate: input.releseDate,
+        saleDate: input.saleDate,
+        deadline: input.deadline,
+        SeriesId: Number(input.seriesId),
+        CategoryId: Number(input.CategoryId)
+      }
+
+      await Product.create(product)
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -1,5 +1,5 @@
 const db = require('../../models')
-const { Product, Category, Series, Image, Tag } = db
+const { Product, Category, Series, Image, Tag, TagItem } = db
 const moment = require('moment')
 const imgur = require('imgur')
 const IMGUR_CLIENT_ID = process.env.IMGUR_CLIENT_ID
@@ -114,8 +114,17 @@ module.exports = {
         SeriesId: Number(input.seriesId),
         CategoryId: Number(input.CategoryId)
       }
+      const newProduct = await Product.create(product)
 
-      await Product.create(product)
+      //寫入TagItem
+      const tagArray = input.tag
+      tagArray.forEach(tagId => {
+        const tagItem = {
+          tag_id: Number(tagId),
+          product_id: newProduct.id
+        }
+        TagItem.create(tagItem)
+      })
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -41,7 +41,7 @@ module.exports = {
   },
 
   getAddPage: (req, res) => {
-    res.render('admin/new')
+    res.render('admin/new', { css: 'adminAdd' })
   },
 
   postDisplay: async (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,17 @@
         "negotiator": "0.6.2"
       }
     },
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -110,16 +121,52 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "bcryptjs": {
       "version": "2.4.3",
@@ -182,6 +229,11 @@
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
       }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
@@ -288,11 +340,18 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -327,6 +386,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -357,6 +429,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "denque": {
       "version": "1.4.1",
@@ -389,6 +466,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -533,11 +619,31 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
     "faker": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
       "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
       "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -569,6 +675,21 @@
       "dev": true,
       "requires": {
         "is-buffer": "~2.0.3"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -611,6 +732,14 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -644,6 +773,20 @@
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -684,12 +827,33 @@
         "toidentifier": "1.0.0"
       }
     },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "imgur": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/imgur/-/imgur-0.3.1.tgz",
+      "integrity": "sha512-G7uUSD4nUIvZwpoBxkADKRGmh6ZDz/8MrxWrXJ6hogAyoYYiwzMzm8RvGjt8LzmHSv8SapCIbyr6BNBV3fLVrA==",
+      "requires": {
+        "commander": "^2.3.0",
+        "glob": "^7.1.2",
+        "q": "^1.0.1",
+        "request": "^2.40.0"
       }
     },
     "inflection": {
@@ -768,6 +932,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -780,6 +949,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -788,6 +962,37 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "just-extend": {
@@ -1111,6 +1316,11 @@
         }
       }
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -1251,6 +1461,11 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "promise": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
@@ -1272,6 +1487,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "psl": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.7.0",
@@ -1305,6 +1535,40 @@
       "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "requires": {
         "esprima": "~4.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "require-directory": {
@@ -1497,6 +1761,22 @@
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
       "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -1566,6 +1846,35 @@
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
       "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
     },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -1604,6 +1913,14 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1623,6 +1940,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,11 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -209,6 +214,20 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -358,6 +377,46 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "connect-flash": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
@@ -449,6 +508,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      }
     },
     "diff": {
       "version": "3.5.0",
@@ -940,8 +1008,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1115,7 +1182,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -1123,8 +1189,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -1207,6 +1272,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
+      "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      }
     },
     "mysql2": {
       "version": "2.0.2",
@@ -1320,6 +1400,11 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -1466,6 +1551,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "promise": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
@@ -1527,6 +1617,17 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "redeyed": {
@@ -1782,6 +1883,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1811,6 +1917,11 @@
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "4.0.0",
@@ -1890,6 +2001,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "uglify-js": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
@@ -1920,6 +2036,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -2031,6 +2152,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "imgur": "^0.3.1",
     "method-override": "^3.0.0",
     "moment": "^2.24.0",
+    "multer": "^1.4.2",
     "mysql2": "^2.0.2",
     "passport": "^0.4.1",
     "passport-local": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "^4.17.1",
     "express-handlebars": "^3.1.0",
     "express-session": "^1.17.0",
+    "imgur": "^0.3.1",
     "method-override": "^3.0.0",
     "moment": "^2.24.0",
     "mysql2": "^2.0.2",

--- a/public/css/adminAdd.css
+++ b/public/css/adminAdd.css
@@ -1,0 +1,7 @@
+.card-cantainer {
+  margin-top: 5rem!important;
+}
+
+/* .form-group {
+  margin-left: 7rem!important;
+} */

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -17,8 +17,10 @@ router.get('/', (req, res) => res.redirect('/admin/products'))
 router.get('/products', prodCtrller.getProducts)
 router.get('/products/new', prodCtrller.getAddPage)
 
+router.post('/products/', prodCtrller.postNewProduct)
 router.post('/products/:id/display', prodCtrller.postDisplay)
 router.post('/products/:id/undisplay', prodCtrller.postUndisplay)
+
 
 router.delete('/products/:id', prodCtrller.deleteProduct)
 

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -23,6 +23,8 @@ router.post('/products/', upload.array('image', 10), prodCtrller.postNewProduct)
 router.post('/products/:id/display', prodCtrller.postDisplay)
 router.post('/products/:id/undisplay', prodCtrller.postUndisplay)
 
+router.put('/products/:id', upload.array('image', 10), prodCtrller.putProduct)
+
 
 router.delete('/products/:id', prodCtrller.deleteProduct)
 

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -20,4 +20,6 @@ router.get('/products/new', prodCtrller.getAddPage)
 router.post('/products/:id/display', prodCtrller.postDisplay)
 router.post('/products/:id/undisplay', prodCtrller.postUndisplay)
 
+router.delete('/products/:id', prodCtrller.deleteProduct)
+
 module.exports = router

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -17,6 +17,7 @@ router.use('/', (req, res, next) => {
 router.get('/', (req, res) => res.redirect('/admin/products'))
 router.get('/products', prodCtrller.getProducts)
 router.get('/products/new', prodCtrller.getAddPage)
+router.get('/products/:id/edit', prodCtrller.getEditPage)
 
 router.post('/products/', upload.array('image', 10), prodCtrller.postNewProduct)
 router.post('/products/:id/display', prodCtrller.postDisplay)

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -17,4 +17,7 @@ router.get('/', (req, res) => res.redirect('/admin/products'))
 router.get('/products', prodCtrller.getProducts)
 router.get('/products/new', prodCtrller.getAddPage)
 
+router.post('/products/:id/display', prodCtrller.postDisplay)
+router.post('/products/:id/undisplay', prodCtrller.postUndisplay)
+
 module.exports = router

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -3,7 +3,8 @@ const prodCtrller = require('../../controllers/admin/prodCtrller.js')
 
 const { isAdminAuth } = require('../../middleware/auth')
 
-
+const multer = require('multer')
+const upload = multer({ dest: 'temp/' })
 
 // route base '/admin'
 router.use('/', isAdminAuth)
@@ -17,7 +18,7 @@ router.get('/', (req, res) => res.redirect('/admin/products'))
 router.get('/products', prodCtrller.getProducts)
 router.get('/products/new', prodCtrller.getAddPage)
 
-router.post('/products/', prodCtrller.postNewProduct)
+router.post('/products/', upload.single('mainImg'), prodCtrller.postNewProduct)
 router.post('/products/:id/display', prodCtrller.postDisplay)
 router.post('/products/:id/undisplay', prodCtrller.postUndisplay)
 

--- a/routes/admin/admin.js
+++ b/routes/admin/admin.js
@@ -18,7 +18,7 @@ router.get('/', (req, res) => res.redirect('/admin/products'))
 router.get('/products', prodCtrller.getProducts)
 router.get('/products/new', prodCtrller.getAddPage)
 
-router.post('/products/', upload.single('mainImg'), prodCtrller.postNewProduct)
+router.post('/products/', upload.array('image', 10), prodCtrller.postNewProduct)
 router.post('/products/:id/display', prodCtrller.postDisplay)
 router.post('/products/:id/undisplay', prodCtrller.postUndisplay)
 

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -143,19 +143,25 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="image" class="col-sm-2 col-form-label text-right">商品圖片</label>
+            <label for="image" class="col-sm-2 col-form-label text-right">新增商品圖片</label>
             <div>
               <div class="custom-file col-sm-7 d-flex align-items-center">
                 <input type="file" name="image" multiple="multiple" id="image">
               </div>
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="image" class="col-sm-2 col-form-label text-right">選擇主圖片</label>
+            <div class="form-check form-check-inline">
               <div class="ml-2 mt-2 row">
                 {{#each images}}
-                  <div class="text-center">
-                    <img src={{this.url}} class="img-thumbnail mx-1 {{#if this.isMain}} border border-primary {{/if}}"
-                      style="width: 100px">
-                    {{#if this.isMain}}
-                      <p>主商品圖</p>
-                    {{/if}}
+                  <div class="text-center mr-1">
+                    <div>
+                      <img src={{this.url}} class="img-thumbnail mx-1" style="width: 100px">
+                    </div>
+                    <input class="form-check-input mt-2" type="radio" name="mainImg" value="{{this.id}}">
                   </div>
                 {{/each}}
               </div>

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -3,7 +3,7 @@
     <ul class="nav nav-pills nav-fill">
       <span class="navbar-brand mb-0 h1">LOGO</span>
       <li class="nav-item">
-        <a class="nav-link active" href="/admin/products/new"><i class="fas fa-plus"></i> 新增商品</a>
+        <a class="nav-link" href="/admin/products/new"><i class="fas fa-plus"></i> 新增商品</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="/admin/products">商品</a>
@@ -20,7 +20,7 @@
   </div>
 </nav>
 <div class="container card-cantainer">
-  <form action="/admin/products" method="POST" enctype="multipart/form-data">
+  <form action="/admin/products/{{product.id}}?_method=PUT" method="POST" enctype="multipart/form-data">
     <div class="card my-3">
       <div class="card-body">
         <h4>基本資訊</h4>
@@ -28,7 +28,7 @@
           <div class="form-group row">
             <label for="name" class="col-sm-2 col-form-label text-right">商品名稱</label>
             <div class="col-sm-7">
-              <input type="text" name="name" class="form-control" id="name">
+              <input type="text" name="name" class="form-control" id="name" value={{product.name}}>
             </div>
           </div>
         </div>
@@ -36,7 +36,7 @@
           <div class="form-group row">
             <label for="slogan" class="col-sm-2 col-form-label text-right">商品標語</label>
             <div class="col-sm-7">
-              <input type="text" name="slogan" class="form-control" id="slogan">
+              <input type="text" name="slogan" class="form-control" id="slogan" value={{product.slogan}}>
             </div>
           </div>
         </div>
@@ -44,7 +44,8 @@
           <div class="form-group row">
             <label for="description" class="col-sm-2 col-form-label text-right">商品內文</label>
             <div class="col-sm-7">
-              <textarea class="form-control" name="description" id="description" rows="3"></textarea>
+              <textarea class="form-control" name="description" id="description"
+                rows="3">{{product.description}}</textarea>
             </div>
           </div>
         </div>
@@ -54,7 +55,9 @@
             <div class="col-sm-7">
               <select class="form-control" name="CategoryId" id="category">
                 {{#each categories}}
-                  <option value={{this.id}}>{{this.name}}</option>
+                  <option value={{this.id}} {{#ifEqual this.id ../product.CategoryId}} selected {{/ifEqual}}>
+                    {{this.name}}
+                  </option>
                 {{/each}}
               </select>
             </div>
@@ -66,7 +69,8 @@
             <div class="col-sm-7 d-flex align-items-center">
               {{#each tag}}
                 <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="checkbox" name="tag[]" value={{this.id}}>
+                  <input class="form-check-input" type="checkbox" name="tag[]" value={{this.id}} {{#if this.checked}}
+                    checked {{/if}}>
                   <label class="form-check-label">{{this.name}}</label>
                 </div>
               {{/each}}
@@ -82,7 +86,7 @@
           <div class="form-group row">
             <label for="price" class="col-sm-2 col-form-label text-right">商品售價</label>
             <div class="col-sm-7">
-              <input type="number" name="price" class="form-control" id="price">
+              <input type="number" name="price" class="form-control" id="price" value={{product.price}}>
             </div>
           </div>
         </div>
@@ -90,7 +94,7 @@
           <div class="form-group row">
             <label for="inventory" class="col-sm-2 col-form-label text-right">商品數量</label>
             <div class="col-sm-7">
-              <input type="number" name="inventory" class="form-control" id="inventory">
+              <input type="number" name="inventory" class="form-control" id="inventory" value={{product.inventory}}>
             </div>
           </div>
         </div>
@@ -98,7 +102,7 @@
           <div class="form-group row">
             <label for="spec" class="col-sm-2 col-form-label text-right">商品規格</label>
             <div class="col-sm-7">
-              <input type="text" name="spec" class="form-control" id="spec">
+              <input type="text" name="spec" class="form-control" id="spec" value={{product.spec}}>
             </div>
           </div>
         </div>
@@ -106,7 +110,7 @@
           <div class="form-group row">
             <label for="releaseDate" class="col-sm-2 col-form-label text-right">公開日期</label>
             <div class="col-sm-7">
-              <input type="date" name="releaseDate" class="form-control" id="releaseDate">
+              <input type="date" name="releaseDate" class="form-control" id="releaseDate" value={{releaseDate}}>
             </div>
           </div>
         </div>
@@ -114,7 +118,7 @@
           <div class="form-group row">
             <label for="deadline" class="col-sm-2 col-form-label text-right">預購截止日期</label>
             <div class="col-sm-7">
-              <input type="date" name="deadline" class="form-control" id="deadline">
+              <input type="date" name="deadline" class="form-control" id="deadline" value={{deadline}}>
             </div>
           </div>
         </div>
@@ -122,7 +126,7 @@
           <div class="form-group row">
             <label for="saleDate" class="col-sm-2 col-form-label text-right">發售日期</label>
             <div class="col-sm-7">
-              <input type="date" name="saleDate" class="form-control" id="saleDate">
+              <input type="date" name="saleDate" class="form-control" id="saleDate" value={{saleDate}}>
             </div>
           </div>
         </div>
@@ -131,8 +135,8 @@
             <label for="status" class="col-sm-2 col-form-label text-right">商品是否上架</label>
             <div class="col-sm-7">
               <select class="form-control" name="status" id="status">
-                <option value="1">是</option>
-                <option value="0">否</option>
+                <option value="1" {{#ifEqual ture product.status}} selected {{/ifEqual}}>是</option>
+                <option value="0" {{#ifEqual false product.status}} selected {{/ifEqual}}>否</option>
               </select>
             </div>
           </div>
@@ -144,7 +148,17 @@
               <div class="custom-file col-sm-7 d-flex align-items-center">
                 <input type="file" name="image" multiple="multiple" id="image">
               </div>
-              <small id="emailHelp" class="form-text text-muted ml-3">預設第一張為商品主圖片</small>
+              <div class="ml-2 mt-2 row">
+                {{#each images}}
+                  <div class="text-center">
+                    <img src={{this.url}} class="img-thumbnail mx-1 {{#if this.isMain}} border border-primary {{/if}}"
+                      style="width: 100px">
+                    {{#if this.isMain}}
+                      <p>主商品圖</p>
+                    {{/if}}
+                  </div>
+                {{/each}}
+              </div>
             </div>
           </div>
         </div>
@@ -159,7 +173,8 @@
             <div class="col-sm-7">
               <select class="form-control" name="seriesId" id="series">
                 {{#each series}}
-                  <option value={{this.id}}>{{this.name}}</option>
+                  <option value={{this.id}} {{#ifEqual this.id ../product.SeriesId}} selected {{/ifEqual}}>{{this.name}}
+                  </option>
                 {{/each}}
               </select>
             </div>
@@ -169,7 +184,7 @@
           <div class="form-group row">
             <label for="copyright" class="col-sm-2 col-form-label text-right">版權</label>
             <div class="col-sm-7">
-              <input type="text" name="copyright" class="form-control" id="copyright">
+              <input type="text" name="copyright" class="form-control" id="copyright" value={{product.copyright}}>
             </div>
           </div>
         </div>
@@ -177,14 +192,14 @@
           <div class="form-group row">
             <label for="maker" class="col-sm-2 col-form-label text-right">廠商</label>
             <div class="col-sm-7">
-              <input type="text" name="maker" class="form-control" id="maker">
+              <input type="text" name="maker" class="form-control" id="maker" value={{product.maker}}>
             </div>
           </div>
         </div>
       </div>
     </div>
     <div class="col-12 text-right">
-      <button class="btn btn-primary" type="submit">新增商品</button>
+      <button class="btn btn-primary" type="submit">更新商品</button>
       </br>
       </br>
     </div>

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -153,18 +153,16 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="image" class="col-sm-2 col-form-label text-right">選擇主圖片</label>
-            <div class="form-check form-check-inline">
-              <div class="ml-2 mt-2 row">
-                {{#each images}}
-                  <div class="text-center mr-1">
-                    <div>
-                      <img src={{this.url}} class="img-thumbnail mx-1" style="width: 100px">
-                    </div>
-                    <input class="form-check-input mt-2" type="radio" name="mainImg" value="{{this.id}}">
-                  </div>
-                {{/each}}
-              </div>
+            <label for="image" class="col-2 col-form-label text-right">選擇主圖片</label>
+            <div class="form-check form-check-inline mr-0 pl-2 col-10 d-flex flex-wrap">
+              {{#each images}}
+                <div class="text-center mr-1">
+                  <label for="{{this.id}}" class="d-block">
+                    <img src={{this.url}} class="img-thumbnail mx-1" style="width: 100px">
+                  </label>
+                  <input id="{{this.id}}" class="form-check-input mt-2" type="radio" name="mainImg" value="{{this.id}}">
+                </div>
+              {{/each}}
             </div>
           </div>
         </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -52,7 +52,7 @@
           <div class="form-group row">
             <label for="category" class="col-sm-2 col-form-label text-right">商品分類</label>
             <div class="col-sm-7">
-              <select class="form-control" name="category" id="category">
+              <select class="form-control" name="CategoryId" id="category">
                 {{#each categories}}
                   <option value={{this.id}}>{{this.name}}</option>
                 {{/each}}
@@ -186,7 +186,7 @@
           <div class="form-group row">
             <label for="series" class="col-sm-2 col-form-label text-right">隸屬作品</label>
             <div class="col-sm-7">
-              <select class="form-control" name="series" id="series">
+              <select class="form-control" name="seriesId" id="series">
                 {{#each series}}
                   <option value={{this.id}}>{{this.name}}</option>
                 {{/each}}

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -66,7 +66,7 @@
             <div class="col-sm-7 d-flex align-items-center">
               {{#each tag}}
                 <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="checkbox" name="tag_{{this.id}}">
+                  <input class="form-check-input" type="checkbox" name="tag[]" value={{this.id}}>
                   <label class="form-check-label">{{this.name}}</label>
                 </div>
               {{/each}}

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -139,41 +139,12 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="mainImg" class="col-sm-2 col-form-label text-right">商品主圖片</label>
-            <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" name="mainImg" id="mainImg">
-            </div>
-          </div>
-        </div>
-        <div class="px-5">
-          <div class="form-group row">
-            <label for="img01" class="col-sm-2 col-form-label text-right">商品其他圖片</label>
-            <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" name="img01" id="img01">
-            </div>
-          </div>
-        </div>
-        <div class="px-5">
-          <div class="form-group row">
-            <label for="img02" class="col-sm-2 col-form-label text-right"> </label>
-            <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" name="img02" id="img02">
-            </div>
-          </div>
-        </div>
-        <div class="px-5">
-          <div class="form-group row">
-            <label for="img03" class="col-sm-2 col-form-label text-right"> </label>
-            <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" name="img03" id="img03">
-            </div>
-          </div>
-        </div>
-        <div class="px-5">
-          <div class="form-group row">
-            <label for="img04" class="col-sm-2 col-form-label text-right"> </label>
-            <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" name="img04" id="img04">
+            <label for="image" class="col-sm-2 col-form-label text-right">商品圖片</label>
+            <div>
+              <div class="custom-file col-sm-7 d-flex align-items-center">
+                <input type="file" name="image" multiple="multiple" id="image">
+              </div>
+              <small id="emailHelp" class="form-text text-muted ml-3">預設第一張為商品主圖片</small>
             </div>
           </div>
         </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -62,11 +62,129 @@
             </div>
           </div>
         </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productCategory" class="col-sm-2 col-form-label text-right">商品標籤</label>
+            <div class="col-sm-7 d-flex align-items-center">
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="category1" value="option1">
+                <label class="form-check-label" for="category1">1</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="category2" value="option2">
+                <label class="form-check-label" for="category2">2</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="category3" value="option2">
+                <label class="form-check-label" for="category3">3</label>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div class="card my-3">
       <div class="card-body">
-        This is some text within a card body.
+        <h4>銷售資訊</h4>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productPrice" class="col-sm-2 col-form-label text-right">商品售價</label>
+            <div class="col-sm-7">
+              <input type="number" class="form-control" id="productPrice">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productInventory" class="col-sm-2 col-form-label text-right">商品數量</label>
+            <div class="col-sm-7">
+              <input type="number" class="form-control" id="productInventory">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productSpec" class="col-sm-2 col-form-label text-right">商品規格</label>
+            <div class="col-sm-7">
+              <input type="text" class="form-control" id="productSpec">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productReleseDate" class="col-sm-2 col-form-label text-right">公開日期</label>
+            <div class="col-sm-7">
+              <input type="date" class="form-control" id="productReleseDate">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productSaleDate" class="col-sm-2 col-form-label text-right">發售日期</label>
+            <div class="col-sm-7">
+              <input type="date" class="form-control" id="productSaleDate">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productDeadline" class="col-sm-2 col-form-label text-right">預購截止日期</label>
+            <div class="col-sm-7">
+              <input type="date" class="form-control" id="productDeadline">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productStatus" class="col-sm-2 col-form-label text-right">商品是否上架</label>
+            <div class="col-sm-7">
+              <select class="form-control" id="productStatus">
+                <option>是</option>
+                <option>否</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productDeadline" class="col-sm-2 col-form-label text-right">商品主圖片</label>
+            <div class="custom-file col-sm-7 d-flex align-items-center">
+              <input type="file" id="projectMainImg">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productDeadline" class="col-sm-2 col-form-label text-right">商品其他圖片</label>
+            <div class="custom-file col-sm-7 d-flex align-items-center">
+              <input type="file" id="projectImg">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productDeadline" class="col-sm-2 col-form-label text-right"> </label>
+            <div class="custom-file col-sm-7 d-flex align-items-center">
+              <input type="file" id="projectImg">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productDeadline" class="col-sm-2 col-form-label text-right"> </label>
+            <div class="custom-file col-sm-7 d-flex align-items-center">
+              <input type="file" id="projectImg">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productDeadline" class="col-sm-2 col-form-label text-right"> </label>
+            <div class="custom-file col-sm-7 d-flex align-items-center">
+              <input type="file" id="projectImg">
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div class="card my-3">

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -66,8 +66,8 @@
             <div class="col-sm-7 d-flex align-items-center">
               {{#each tag}}
                 <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="checkbox" name="tag[]" value={{this.id}}>
-                  <label class="form-check-label">{{this.name}}</label>
+                  <input class="form-check-input" type="checkbox" name="tag[]" id="tag_{{this.id}}" value={{this.id}}>
+                  <label class="form-check-label" for="tag_{{this.id}}">{{this.name}}</label>
                 </div>
               {{/each}}
             </div>
@@ -88,7 +88,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="inventory" class="col-sm-2 col-form-label text-right">商品數量</label>
+            <label for="inventory" class="col-sm-2 col-form-label text-right">商品庫存</label>
             <div class="col-sm-7">
               <input type="number" name="inventory" class="form-control" id="inventory">
             </div>
@@ -132,7 +132,7 @@
             <div class="col-sm-7">
               <select class="form-control" name="status" id="status">
                 <option value="1">是</option>
-                <option value="0">否</option>
+                <option value="0" selected>否</option>
               </select>
             </div>
           </div>
@@ -144,7 +144,8 @@
               <div class="custom-file col-sm-7 d-flex align-items-center">
                 <input type="file" name="image" multiple="multiple" id="image">
               </div>
-              <small id="emailHelp" class="form-text text-muted ml-3">預設第一張為商品主圖片</small>
+              <small id="emailHelp" class="form-text text-muted ml-3">＊ 預設第一張為商品主圖片</small>
+              <small id="emailHelp" class="form-text text-muted ml-3">＊ 建議大小為570x670px</small>
             </div>
           </div>
         </div>
@@ -167,7 +168,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="copyright" class="col-sm-2 col-form-label text-right">版權</label>
+            <label for="copyright" class="col-sm-2 col-form-label text-right">版權所屬</label>
             <div class="col-sm-7">
               <input type="text" name="copyright" class="form-control" id="copyright">
             </div>
@@ -175,7 +176,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="maker" class="col-sm-2 col-form-label text-right">廠商</label>
+            <label for="maker" class="col-sm-2 col-form-label text-right">製造商</label>
             <div class="col-sm-7">
               <input type="text" name="maker" class="form-control" id="maker">
             </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -1,6 +1,7 @@
-<div class="card">
-  <div class="card-header">
-    <ul class="nav nav-tabs card-header-tabs">
+<nav class="navbar fixed-top navbar-light bg-light">
+  <div class="container">
+    <ul class="nav nav-pills nav-fill">
+      <span class="navbar-brand mb-0 h1">LOGO</span>
       <li class="nav-item">
         <a class="nav-link active" href="/admin/products/new"><i class="fas fa-plus"></i> 新增商品</a>
       </li>
@@ -13,71 +14,65 @@
       <li class="nav-item">
         <a class="nav-link" href="/admin/users">會員</a>
       </li>
+      <br>
     </ul>
+    <a class="btn btn-outline-secondary ml-3" href="/signout">登出</a>
   </div>
-  <div class="card-body">
-    <form action="/admin/products" method="POST" enctype="multipart/form-data">
-      <div class="row">
-        <div class="col-5 mx-auto">
-          <div class="form-group">
-            <label for="name">商品名稱</label>
-            <input type="text" class="form-control" id="name">
-          </div>
-          <div class="form-group">
-            <label for="slogan">標語</label>
-            <input type="text" class="form-control" id="slogan">
-          </div>
-          <div class="form-group">
-            <label for="deseription">介紹</label>
-            <textarea class="form-control" id="deseription"></textarea>
-          </div>
-          <div class="form-group">
-            <label for="image">商品圖片</label>
-            <input type="file" class="form-control-file" id="image" name="image">
-          </div>
-          <div class="form-group">
-            <label for="spec">規格</label>
-            <input type="text" class="form-control" id="spec">
-          </div>
-          <div class="form-group">
-            <label for="copyright">版權</label>
-            <input type="text" class="form-control" id="copyright">
-          </div>
-          <div class="form-group">
-            <label for="maker">廠商</label>
-            <input type="text" class="form-control" id="maker">
+</nav>
+<div class="container card-cantainer">
+  <form action="">
+    <div class="card my-3">
+      <div class="card-body">
+        <h4>基本資訊</h4>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productName" class="col-sm-2 col-form-label text-right">商品名稱</label>
+            <div class="col-sm-7">
+              <input type="text" class="form-control" id="productName">
+            </div>
           </div>
         </div>
-        <div class="col-5 mx-auto">
-          <div class="form-group">
-            <label for="price">售價</label>
-            <input type="text" class="form-control" id="price">
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productSlogan" class="col-sm-2 col-form-label text-right">商品標語</label>
+            <div class="col-sm-7">
+              <input type="text" class="form-control" id="productName">
+            </div>
           </div>
-          <div class="form-group">
-            <label for="intenvory">庫存</label>
-            <input type="text" class="form-control" id="intenvory">
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productDescription" class="col-sm-2 col-form-label text-right">商品內文</label>
+            <div class="col-sm-7">
+              <textarea class="form-control" id="productDescription" rows="3"></textarea>
+            </div>
           </div>
-          <div class="form-group">
-            <label for="state">上架狀態</label>
-            <select id="state" class="form-control">
-              <option selected>是</option>
-              <option>否</option>
-            </select>
-          </div>
-          <div class="form-group">
-            <label for="releaseDate">公開日期</label>
-            <input type="date" class="form-control" id="releaseDate">
-          </div>
-          <div class="form-group">
-            <label for="saleDate">發售日</label>
-            <input type="date" class="form-control" id="saleDate">
-          </div>
-          <div class="form-group">
-            <label for="deadline">預購截止日</label>
-            <input type="date" class="form-control" id="deadline">
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productCategory" class="col-sm-2 col-form-label text-right">商品分類</label>
+            <div class="col-sm-7">
+              <select class="form-control" id="productCategory">
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option>5</option>
+              </select>
+            </div>
           </div>
         </div>
       </div>
-    </form>
-  </div>
+    </div>
+    <div class="card my-3">
+      <div class="card-body">
+        This is some text within a card body.
+      </div>
+    </div>
+    <div class="card my-3">
+      <div class="card-body">
+        This is some text within a card body.
+      </div>
+    </div>
+  </form>
 </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -158,7 +158,7 @@
           <div class="form-group row">
             <label for="series" class="col-sm-2 col-form-label text-right">隸屬作品</label>
             <div class="col-sm-7">
-              <select class="form-control" name="seriesId" id="series">
+              <select class="form-control" name="SeriesId" id="series">
                 {{#each series}}
                   <option value={{this.id}}>{{this.name}}</option>
                 {{/each}}

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -144,8 +144,9 @@
               <div class="custom-file col-sm-7 d-flex align-items-center">
                 <input type="file" name="image" multiple="multiple" id="image">
               </div>
-              <small id="emailHelp" class="form-text text-muted ml-3">＊ 預設第一張為商品主圖片</small>
-              <small id="emailHelp" class="form-text text-muted ml-3">＊ 建議大小為570x670px</small>
+              <small id="emailHelp" class="form-text text-muted ml-3">
+                <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>
+              </small>
             </div>
           </div>
         </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -26,58 +26,50 @@
         <h4>基本資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productName" class="col-sm-2 col-form-label text-right">商品名稱</label>
+            <label for="name" class="col-sm-2 col-form-label text-right">商品名稱</label>
             <div class="col-sm-7">
-              <input type="text" class="form-control" id="productName">
+              <input type="text" name="name" class="form-control" id="name">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productSlogan" class="col-sm-2 col-form-label text-right">商品標語</label>
+            <label for="slogan" class="col-sm-2 col-form-label text-right">商品標語</label>
             <div class="col-sm-7">
-              <input type="text" class="form-control" id="productName">
+              <input type="text" name="slogan" class="form-control" id="slogan">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productDescription" class="col-sm-2 col-form-label text-right">商品內文</label>
+            <label for="description" class="col-sm-2 col-form-label text-right">商品內文</label>
             <div class="col-sm-7">
-              <textarea class="form-control" id="productDescription" rows="3"></textarea>
+              <textarea class="form-control" name="description" id="description" rows="3"></textarea>
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productCategory" class="col-sm-2 col-form-label text-right">商品分類</label>
+            <label for="category" class="col-sm-2 col-form-label text-right">商品分類</label>
             <div class="col-sm-7">
-              <select class="form-control" id="productCategory">
-                <option>1</option>
-                <option>2</option>
-                <option>3</option>
-                <option>4</option>
-                <option>5</option>
+              <select class="form-control" name="category" id="category">
+                {{#each categories}}
+                  <option value={{this.id}}>{{this.name}}</option>
+                {{/each}}
               </select>
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productCategory" class="col-sm-2 col-form-label text-right">商品標籤</label>
+            <label for="tag" class="col-sm-2 col-form-label text-right">商品標籤</label>
             <div class="col-sm-7 d-flex align-items-center">
-              <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" id="category1" value="option1">
-                <label class="form-check-label" for="category1">1</label>
-              </div>
-              <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" id="category2" value="option2">
-                <label class="form-check-label" for="category2">2</label>
-              </div>
-              <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" id="category3" value="option2">
-                <label class="form-check-label" for="category3">3</label>
-              </div>
+              {{#each tag}}
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="checkbox" name="tag_{{this.id}}">
+                  <label class="form-check-label">{{this.name}}</label>
+                </div>
+              {{/each}}
             </div>
           </div>
         </div>
@@ -88,100 +80,100 @@
         <h4>銷售資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productPrice" class="col-sm-2 col-form-label text-right">商品售價</label>
+            <label for="price" class="col-sm-2 col-form-label text-right">商品售價</label>
             <div class="col-sm-7">
-              <input type="number" class="form-control" id="productPrice">
+              <input type="number" name="price" class="form-control" id="price">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productInventory" class="col-sm-2 col-form-label text-right">商品數量</label>
+            <label for="inventory" class="col-sm-2 col-form-label text-right">商品數量</label>
             <div class="col-sm-7">
-              <input type="number" class="form-control" id="productInventory">
+              <input type="number" name="inventory" class="form-control" id="inventory">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productSpec" class="col-sm-2 col-form-label text-right">商品規格</label>
+            <label for="spec" class="col-sm-2 col-form-label text-right">商品規格</label>
             <div class="col-sm-7">
-              <input type="text" class="form-control" id="productSpec">
+              <input type="text" name="spec" class="form-control" id="spec">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productReleseDate" class="col-sm-2 col-form-label text-right">公開日期</label>
+            <label for="releseDate" class="col-sm-2 col-form-label text-right">公開日期</label>
             <div class="col-sm-7">
-              <input type="date" class="form-control" id="productReleseDate">
+              <input type="date" name="releseDate" class="form-control" id="releseDate">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productSaleDate" class="col-sm-2 col-form-label text-right">發售日期</label>
+            <label for="deadline" class="col-sm-2 col-form-label text-right">預購截止日期</label>
             <div class="col-sm-7">
-              <input type="date" class="form-control" id="productSaleDate">
+              <input type="date" name="deadline" class="form-control" id="deadline">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productDeadline" class="col-sm-2 col-form-label text-right">預購截止日期</label>
+            <label for="saleDate" class="col-sm-2 col-form-label text-right">發售日期</label>
             <div class="col-sm-7">
-              <input type="date" class="form-control" id="productDeadline">
+              <input type="date" name="saleDate" class="form-control" id="saleDate">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productStatus" class="col-sm-2 col-form-label text-right">商品是否上架</label>
+            <label for="status" class="col-sm-2 col-form-label text-right">商品是否上架</label>
             <div class="col-sm-7">
-              <select class="form-control" id="productStatus">
-                <option>是</option>
-                <option>否</option>
+              <select class="form-control" name="status" id="status">
+                <option value="1">是</option>
+                <option value="0">否</option>
               </select>
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="projectMainImg" class="col-sm-2 col-form-label text-right">商品主圖片</label>
+            <label for="mainImg" class="col-sm-2 col-form-label text-right">商品主圖片</label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectMainImg">
+              <input type="file" name="mainImg" id="mainImg">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="projectImg01" class="col-sm-2 col-form-label text-right">商品其他圖片</label>
+            <label for="img01" class="col-sm-2 col-form-label text-right">商品其他圖片</label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectImg01">
+              <input type="file" name="img01" id="img01">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="projectImg02" class="col-sm-2 col-form-label text-right"> </label>
+            <label for="img02" class="col-sm-2 col-form-label text-right"> </label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectImg02">
+              <input type="file" name="img02" id="img02">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="projectImg03" class="col-sm-2 col-form-label text-right"> </label>
+            <label for="img03" class="col-sm-2 col-form-label text-right"> </label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectImg03">
+              <input type="file" name="img03" id="img03">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="projectImg04" class="col-sm-2 col-form-label text-right"> </label>
+            <label for="img04" class="col-sm-2 col-form-label text-right"> </label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectImg04">
+              <input type="file" name="img04" id="img04">
             </div>
           </div>
         </div>
@@ -192,31 +184,29 @@
         <h4>其他資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productSeries" class="col-sm-2 col-form-label text-right">隸屬作品</label>
+            <label for="series" class="col-sm-2 col-form-label text-right">隸屬作品</label>
             <div class="col-sm-7">
-              <select class="form-control" id="productSeries">
-                <option>1</option>
-                <option>2</option>
-                <option>3</option>
-                <option>4</option>
-                <option>5</option>
+              <select class="form-control" name="series" id="series">
+                {{#each series}}
+                  <option value={{this.id}}>{{this.name}}</option>
+                {{/each}}
               </select>
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productCopyright" class="col-sm-2 col-form-label text-right">版權</label>
+            <label for="copyright" class="col-sm-2 col-form-label text-right">版權</label>
             <div class="col-sm-7">
-              <input type="text" class="form-control" id="productCopyright">
+              <input type="text" name="copyright" class="form-control" id="copyright">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productMaker" class="col-sm-2 col-form-label text-right">廠商</label>
+            <label for="maker" class="col-sm-2 col-form-label text-right">廠商</label>
             <div class="col-sm-7">
-              <input type="text" class="form-control" id="productMaker">
+              <input type="text" name="maker" class="form-control" id="maker">
             </div>
           </div>
         </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -20,7 +20,7 @@
   </div>
 </nav>
 <div class="container card-cantainer">
-  <form action="/admin/products" method="POST">
+  <form action="/admin/products" method="POST" enctype="multipart/form-data">
     <div class="card my-3">
       <div class="card-body">
         <h4>基本資訊</h4>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -20,7 +20,7 @@
   </div>
 </nav>
 <div class="container card-cantainer">
-  <form action="">
+  <form action="/admin/products" method="POST">
     <div class="card my-3">
       <div class="card-body">
         <h4>基本資訊</h4>
@@ -221,6 +221,11 @@
           </div>
         </div>
       </div>
+    </div>
+    <div class="col-12 text-right">
+      <button class="btn btn-primary" type="submit">新增商品</button>
+      </br>
+      </br>
     </div>
   </form>
 </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -147,7 +147,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productDeadline" class="col-sm-2 col-form-label text-right">商品主圖片</label>
+            <label for="projectMainImg" class="col-sm-2 col-form-label text-right">商品主圖片</label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
               <input type="file" id="projectMainImg">
             </div>
@@ -155,33 +155,33 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productDeadline" class="col-sm-2 col-form-label text-right">商品其他圖片</label>
+            <label for="projectImg01" class="col-sm-2 col-form-label text-right">商品其他圖片</label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectImg">
+              <input type="file" id="projectImg01">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productDeadline" class="col-sm-2 col-form-label text-right"> </label>
+            <label for="projectImg02" class="col-sm-2 col-form-label text-right"> </label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectImg">
+              <input type="file" id="projectImg02">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productDeadline" class="col-sm-2 col-form-label text-right"> </label>
+            <label for="projectImg03" class="col-sm-2 col-form-label text-right"> </label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectImg">
+              <input type="file" id="projectImg03">
             </div>
           </div>
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="productDeadline" class="col-sm-2 col-form-label text-right"> </label>
+            <label for="projectImg04" class="col-sm-2 col-form-label text-right"> </label>
             <div class="custom-file col-sm-7 d-flex align-items-center">
-              <input type="file" id="projectImg">
+              <input type="file" id="projectImg04">
             </div>
           </div>
         </div>
@@ -189,7 +189,37 @@
     </div>
     <div class="card my-3">
       <div class="card-body">
-        This is some text within a card body.
+        <h4>其他資訊</h4>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productSeries" class="col-sm-2 col-form-label text-right">隸屬作品</label>
+            <div class="col-sm-7">
+              <select class="form-control" id="productSeries">
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option>5</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productCopyright" class="col-sm-2 col-form-label text-right">版權</label>
+            <div class="col-sm-7">
+              <input type="text" class="form-control" id="productCopyright">
+            </div>
+          </div>
+        </div>
+        <div class="px-5">
+          <div class="form-group row">
+            <label for="productMaker" class="col-sm-2 col-form-label text-right">廠商</label>
+            <div class="col-sm-7">
+              <input type="text" class="form-control" id="productMaker">
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </form>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -79,11 +79,6 @@
                 <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark "><i
                     class="fas fa-edit" title="編輯此商品"></i></a>
               </button>
-              {{!-- <button type="button" class="btn font-weight-normal">
-                <a href="/admin/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark ">
-                  <i class="fas fa-search-plus" title="商品詳情"></i>
-                </a>
-              </button> --}}
               <!-- Detail Button trigger modal -->
               <button type="button" class="btn font-weight-normal" data-toggle="modal"
                 data-target=".detailModal{{this.id}}"><i class="fas fa-search-plus" title="商品詳情"></i></button>
@@ -132,33 +127,48 @@
                   </button>
                 </div>
                 <div class="modal-body">
+                  <h4>#{{this.id}} {{this.name}}</h4>
+                  <hr>
                   <div class="row">
-                    <div class="col-6 d-flex justify-content-start flex-wrap">
-                      {{#each this.Images}}
-                        <img src="{{this.url}}" class="rounded mx-1" alt="productImage" style="height:100px">
-                      {{/each}}
+                    <div class="col-6 ">
+                      <p>商品標語： {{this.slogan}}</p>
+                      <p>商品內文：{{this.description}}</p>
                     </div>
                     <div class="col-6">
                       <div>
-                        <h4>#{{this.id}} {{this.name}}</h4>
-                        <p>售價 {{this.price}}</p>
-                        <p>庫存 {{this.inventory}}</p>
-                        <p>規格 {{this.spec}}</p>
-                        <p>版權 {{this.copyright}}</p>
-                        <p>廠商 {{this.maker}}</p>
+                        <p>售價： {{this.price}}</p>
+                        <p>庫存： {{this.inventory}}</p>
+                        <p>規格： {{this.spec}}</p>
+                        <p>版權： {{this.copyright}}</p>
+                        <p>廠商： {{this.maker}}</p>
                         {{#if this.status}}
-                          <p>狀態 上架中</p>
+                          <p>狀態： 上架中</p>
                         {{else}}
-                          <p>狀態 未上架</p>
+                          <p>狀態： 未上架</p>
                         {{/if}}
-                        <p>分類 {{this.Category.name}}</p>
-                        <p>作品 {{this.Series.name}}</p>
+                        <p>分類： {{this.Category.name}}</p>
+                        <p>作品： {{this.Series.name}}</p>
+                      </div>
+                    </div>
+                  </div>
+                  <hr>
+                  <div>
+                    <p class="md-2">商品圖片：</p>
+                    <div class="row">
+                      <div class="col-2 text-center">
+                        <img src="{{this.mainImg}}" class="rounded mx-1 mb-2 border border-primary" alt="productImage"
+                          style="height:100px">
+                        <p>主圖片</p>
+                      </div>
+                      <div class="col-10">
+                        {{#each this.secondImg}}
+                          <img src="{{this.url}}" class="rounded mx-1 mb-2" alt="productImage" style="height:100px">
+                        {{/each}}
                       </div>
                     </div>
                   </div>
                 </div>
                 <div class="modal-footer">
-                  <a href=""></a>
                   <button type="button" class="btn font-weight-normal">
                     <a href="/admin/products/{{this.id}}/edit" class="btn btn-primary">編輯此商品</a>
                   </button>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -58,11 +58,15 @@
             <td>{{this.saleStatus}}</td>
             <td>
               {{#if this.status}}
+                <p hidden>1</p>
+                {{!-- 排序用 --}}
                 <form action="/admin/products/{{this.id}}/undisplay" method="POST">
                   <input type="text" name="id" hidden>
                   <button type="submit" class="btn" title="將此商品下架"><i class="far fa-circle text-success"></i></button>
                 </form>
               {{else}}
+                <p hidden>0</p>
+                {{!-- 排序用 --}}
                 <form action="/admin/products/{{this.id}}/display" method="POST">
                   <input type="text" name="id" hidden>
                   <button type="submit" class="btn" title="將此商品上架"><i class="fas fa-times text-danger"></i>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -133,12 +133,9 @@
                 </div>
                 <div class="modal-body">
                   <div class="row">
-                    <div class="col-6 d-flex flex-wrap">
+                    <div class="col-6 d-flex justify-content-start flex-wrap">
                       {{#each this.Images}}
-                        <div class="p-2 flex-fill bd-highlight">
-                          <img src="{{this.url}}" class="rounded mx-auto d-block" alt="productImage"
-                            style="height:100px">
-                        </div>
+                        <img src="{{this.url}}" class="rounded mx-1" alt="productImage" style="height:100px">
                       {{/each}}
                     </div>
                     <div class="col-6">

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -79,11 +79,14 @@
                 <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark "><i
                     class="fas fa-edit" title="編輯此商品"></i></a>
               </button>
-              <button type="button" class="btn font-weight-normal">
+              {{!-- <button type="button" class="btn font-weight-normal">
                 <a href="/admin/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark ">
                   <i class="fas fa-search-plus" title="商品詳情"></i>
                 </a>
-              </button>
+              </button> --}}
+              <!-- Detail Button trigger modal -->
+              <button type="button" class="btn font-weight-normal" data-toggle="modal"
+                data-target=".detailModal{{this.id}}"><i class="fas fa-search-plus" title="商品詳情"></i></button>
               <!-- Delete Button trigger modal -->
               <button type="button" class="btn font-weight-normal" data-toggle="modal" data-target="#delete_{{this.id}}"
                 title="刪除此商品">
@@ -114,6 +117,55 @@
                     <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
                     </button>
                   </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          {{!--detail product modal --}}
+          <div class="modal fade detailModal{{this.id}}" tabindex="-1" role="dialog">
+            <div class="modal-dialog modal-lg" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title">商品詳細</h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                </div>
+                <div class="modal-body">
+                  <div class="row">
+                    <div class="col-6 d-flex flex-wrap">
+                      {{#each this.Images}}
+                        <div class="p-2 flex-fill bd-highlight">
+                          <img src="{{this.url}}" class="rounded mx-auto d-block" alt="productImage"
+                            style="height:100px">
+                        </div>
+                      {{/each}}
+                    </div>
+                    <div class="col-6">
+                      <div>
+                        <h4>#{{this.id}} {{this.name}}</h4>
+                        <p>售價 {{this.price}}</p>
+                        <p>庫存 {{this.inventory}}</p>
+                        <p>規格 {{this.spec}}</p>
+                        <p>版權 {{this.copyright}}</p>
+                        <p>廠商 {{this.maker}}</p>
+                        {{#if this.status}}
+                          <p>狀態 上架中</p>
+                        {{else}}
+                          <p>狀態 未上架</p>
+                        {{/if}}
+                        <p>分類 {{this.Category.name}}</p>
+                        <p>作品 {{this.Series.name}}</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="modal-footer">
+                  <a href=""></a>
+                  <button type="button" class="btn font-weight-normal">
+                    <a href="/admin/products/{{this.id}}/edit" class="btn btn-primary">編輯此商品</a>
+                  </button>
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 </div>
               </div>
             </div>

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -10,11 +10,10 @@
     integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.1/css/all.min.css">
   <link href="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/css/main.css">
   {{#if css}}
     <link rel="stylesheet" href="/css/{{css}}.css">
   {{/if}}
-  <title>GreatSmile Online Shop</title>
+  <title>您正在後台，請微笑(*´д`)~♥</title>
 </head>
 
 <body>


### PR DESCRIPTION
## 引入套件
`npm i`
- imgur
- multer

## 環境變數
- `.env`加入IMGUR_CLIENT_ID，須自行新增在本地端
- 已放在trello > sprint 1> 資料暫存區> .env

## 手動測試目標
### 新增商品
<img width="1440" alt="螢幕快照 2019-12-27 上午1 42 54" src="https://user-images.githubusercontent.com/49901777/71485206-ebfae200-284a-11ea-85c0-0ab4c0c23317.png">

- 可以從nav bar進入新增商品頁面
- 在新增商品頁面中新增一項商品
- 新增過程中可以選擇多張圖片上傳
- 新增完畢後導回後台商品一覽頁面
- 確認第一張選擇上傳的照片為mainImg
- 尚未有表單驗證功能(之後連同alert message一起追加)

### 上下架控制
<img width="125" alt="螢幕快照 2019-12-27 上午1 53 39" src="https://user-images.githubusercontent.com/49901777/71485386-bc98a500-284b-11ea-8a25-47b814d49afc.png">

- 可點擊上架狀態欄位的圖示變更上架/下架狀態
- 上下架狀態亦可於新增商品/編輯商品做修改

### 商品編輯
<img width="1440" alt="螢幕快照 2019-12-27 上午1 56 05" src="https://user-images.githubusercontent.com/49901777/71485481-2ca72b00-284c-11ea-83af-c3d3a48ca211.png">

- 點擊商品編輯圖示可以連至編輯頁面
- 可於編輯頁面修改商品資訊
- 可以上傳新商品圖片
- 可以重新指定mainImg
- 送出後會導回後台商品一覽頁面
- 後台商品一覽頁面可以顯示修改後的資訊

### 商品詳細
<img width="1440" alt="螢幕快照 2019-12-27 上午1 58 15" src="https://user-images.githubusercontent.com/49901777/71485522-60825080-284c-11ea-97de-885a56873e1f.png">

- 點擊詳細圖示可以開啟modal顯示詳細資訊
- 可從modal連至商品編輯頁面
- 版面等待靈感重新設計...求建議XD

### 商品刪除
<img width="1440" alt="螢幕快照 2019-12-27 上午2 00 21" src="https://user-images.githubusercontent.com/49901777/71485569-a8a17300-284c-11ea-8d89-677013b42f9d.png">

- 點擊刪除按鈕會跳出確認modal
- 再次點擊確認刪除可以刪除該商品