### PR TITLE
【加入】後台訂單頁

### DIFF
--- a/controllers/admin/orderCtrller.js
+++ b/controllers/admin/orderCtrller.js
@@ -1,0 +1,9 @@
+const db = require('../../models')
+const { Order } = db
+
+
+module.exports = {
+  getOrders: (req, res) => {
+    res.send('order page')
+  },
+}

--- a/controllers/admin/orderCtrller.js
+++ b/controllers/admin/orderCtrller.js
@@ -20,10 +20,10 @@ module.exports = {
         order.createdTime = order.createdAt.toJSON().split('T')[0]
         order.products.forEach(product => {
           product.mainImg = product.Images.find(img => img.isMain).url
-          product.subPrice = product.OrderItem.quantity * product.price
+          product.subPrice = product.OrderItem.quantity * product.OrderItem.price
         })
       })
-      console.log(orders[0])
+
       res.render('admin/orders', { orders })
     } catch (err) {
       console.error(err)

--- a/controllers/admin/orderCtrller.js
+++ b/controllers/admin/orderCtrller.js
@@ -1,9 +1,24 @@
 const db = require('../../models')
-const { Order } = db
+const { Order, User } = db
 
 
 module.exports = {
-  getOrders: (req, res) => {
-    res.send('order page')
+  getOrders: async (req, res) => {
+    try {
+      const orders = await Order.findAll({
+        order: [['id', 'DESC']],
+        include: [User]
+      })
+
+      orders.forEach(order => {
+        order.createdTime = order.createdAt.toJSON().split('T')[0]
+      })
+
+      console.log(orders[0])
+      res.render('admin/orders', { orders })
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
   },
 }

--- a/controllers/admin/orderCtrller.js
+++ b/controllers/admin/orderCtrller.js
@@ -1,5 +1,5 @@
 const db = require('../../models')
-const { Order, User } = db
+const { Order, User, Product } = db
 
 
 module.exports = {
@@ -7,13 +7,22 @@ module.exports = {
     try {
       const orders = await Order.findAll({
         order: [['id', 'DESC']],
-        include: [User]
+        include: [
+          { model: User },
+          {
+            model: Product, as: 'products',
+            include: ['Gifts', 'Images']
+          }
+        ]
       })
 
       orders.forEach(order => {
         order.createdTime = order.createdAt.toJSON().split('T')[0]
+        order.products.forEach(product => {
+          product.mainImg = product.Images.find(img => img.isMain).url
+          product.subPrice = product.OrderItem.quantity * product.price
+        })
       })
-
       console.log(orders[0])
       res.render('admin/orders', { orders })
     } catch (err) {

--- a/controllers/admin/userCtrller.js
+++ b/controllers/admin/userCtrller.js
@@ -1,17 +1,20 @@
 const db = require('../../models')
-const { User } = db
+const { User, Order } = db
 
 
 module.exports = {
   getUsers: async (req, res) => {
     try {
       const users = await User.findAll({
-        order: [['id', 'DESC']]
+        order: [['id', 'DESC']],
+        include: [Order]
       })
 
       users.forEach(user => {
         user.modifybirthday = user.birthday.toJSON().split('T')[0]
+        user.orderCount = user.Orders.length
       })
+
 
       res.render('admin/users', { users })
     } catch (err) {

--- a/controllers/cartCtrller.js
+++ b/controllers/cartCtrller.js
@@ -9,13 +9,12 @@ moment.locale('zh-tw')
 module.exports = {
   getCart: async (req, res) => {
     try {
-      let cart = await Cart.findByPk(req.session.cartId, { 
+      let cart = await Cart.findByPk(req.session.cartId, {
         include: [{
           model: Product, as: 'products',
           include: ['Gifts', 'Images']
         }]
       })
-      
       cart = cart || { products: [] }
       let cartProducts = cart.products
       let totalPrice = 0
@@ -59,7 +58,7 @@ module.exports = {
       await req.session.save()
 
       // 確認 CartItem 是否已有 record，若無建一個
-      const [cartItem, wasCreated] = await CartItem.findOrCreate({ 
+      const [cartItem, wasCreated] = await CartItem.findOrCreate({
         where: { CartId: cart.id, product_id },
         include: { model: Product, attributes: ['inventory'] }
       })
@@ -83,12 +82,12 @@ module.exports = {
       // 計算商品數量
       if (currentQty + inputQty > QTY_Limit) {
         await cartItem.update({ quantity: QTY_Limit })
-        req.flash('addedItem', { 
+        req.flash('addedItem', {
           productName, productImg, msg: '超過單件商品之最大購買數量，已為您調整為最大購買數量。'
         })
         return res.redirect('back')
-      } 
-      
+      }
+
       await cartItem.update({ quantity: (currentQty + inputQty) })
       req.flash('addedItem', { productName, productImg, msg: '已成功加進購物車' })
       res.redirect('back')

--- a/models/product.js
+++ b/models/product.js
@@ -34,8 +34,8 @@ module.exports = (sequelize, DataTypes) => {
     })
     Product.belongsToMany(models.Order, {
       through: models.OrderItem,
-      foreignKey: 'order_id',
-      as: 'orders'
+      foreignKey: 'product_id',
+      as: 'products'
     })
   };
   return Product;

--- a/public/css/admin/admin.css
+++ b/public/css/admin/admin.css
@@ -22,5 +22,4 @@ main.container {
 .card-body {
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
-  padding: 0rem;
 }

--- a/routes/admin/index.js
+++ b/routes/admin/index.js
@@ -13,5 +13,6 @@ router.get('/', (req, res) => res.redirect('/admin/products'))
 
 router.use('/products', require('./products.js'))
 router.use('/users', require('./users.js'))
+router.use('/orders', require('./orders.js'))
 
 module.exports = router

--- a/routes/admin/orders.js
+++ b/routes/admin/orders.js
@@ -1,0 +1,7 @@
+const router = require('express').Router()
+const orderCtrller = require('../../controllers/admin/orderCtrller')
+
+// route base '/admin/orders'
+router.get('/', orderCtrller.getOrders)
+
+module.exports = router

--- a/views/admin/orders.hbs
+++ b/views/admin/orders.hbs
@@ -10,7 +10,7 @@
           <th data-valign="middle" class="text-center" data-sortable="true">付款方式</th>
           <th data-valign="middle" class="text-center" data-sortable="true">付款狀態</th>
           <th data-valign="middle" class="text-center" data-sortable="true">出貨狀態</th>
-          <th data-valign="middle" class="text-center" data-sortable="true">會員帳號</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">收件人</th>
           <th data-valign="middle" class="text-center">訂單操作</th>
         </tr>
       </thead>
@@ -36,7 +36,7 @@
                 <i class="fas fa-times text-danger"></i>
               {{/if}}
             </td>
-            <td>{{this.User.email}}</td>
+            <td>{{this.receiver}}</td>
             <td>
               {{!--detail Button trigger modal --}}
               <button type="button" class="btn btn-outline-dark mr-1" data-toggle="modal"
@@ -58,6 +58,18 @@
                     </button>
                   </div>
                   <div class="modal-body">
+                    <div class="row col-12">
+                      <div class="col-6">
+                        <p>訂購人：{{this.User.name}} </p>
+                      </div>
+                      <div class="col-6">
+                        <p>聯絡電話：{{this.User.phone}}</p>
+                      </div>
+                      <div class="col-12">
+                        <p class="mb-0">會員信箱：{{this.User.email}}</p>
+                      </div>
+                    </div>
+                    <hr>
                     <div class="row col-12">
                       <div class="col-6">
                         <p>收件人：{{this.receiver}}</p>
@@ -93,7 +105,7 @@
                           </div>
                           <div class="col-5 text-center ml-4 pr-0">
                             <div class="d-flex justify-content-between">
-                              <span class="mr-5">NTD {{this.price}}</span>
+                              <span class="mr-5">NTD {{this.OrderItem.price}}</span>
                               <span>
                                 <div class="d-flex align-items-center">
                                   <span class="pr-4">

--- a/views/admin/orders.hbs
+++ b/views/admin/orders.hbs
@@ -40,39 +40,82 @@
               {{/if}}
             </td>
             <td>{{this.User.email}}</td>
-            {{!-- <td>{{this.receiver}}</td>
-            <td>{{this.address}}</td>
-            <td>{{this.phone}}</td> --}}
-            {{!-- <td>
-              {{#ifEqual this.gender 'M'}}<i class="fas fa-mars text-primary"></i>{{/ifEqual}}
-              {{#ifEqual this.gender 'F'}}<i class="fas fa-venus text-danger"></i>{{/ifEqual}}
-            </td>
-            <td>
-              {{#if this.orderCount}}
-                {{this.orderCount}}
-              {{else}}
-                -
-              {{/if}}
-            </td>
-            <td>
-              {{#if this.isAdmin}}
-                <i class="fas fa-check text-success"></i>
-              {{else}}
-                <i class="fas fa-times text-danger"></i>
-              {{/if}}
-            </td> --}}
             <td>
               <a href="/admin/user/{{this.id}}/edit " class="btn btn-outline-dark mr-1"><i class="fas fa-edit"
                   title="編輯會員資料"></i></a>
-              <a href="#" target="_blank" class="btn btn-outline-dark mr-1">
-                <i class="fas fa-search-plus" title="詳細資料"></i>
-              </a>
+              <button type="button" class="btn btn-outline-dark mr-1" data-toggle="modal"
+                data-target=".orderModal{{this.id}}"><i class="fas fa-search-plus" title="訂單詳情"></i></button>
               <!-- Delete Button trigger modal -->
               <button type="button" class="btn btn-outline-dark" data-toggle="modal" data-target="#delete_{{this.id}}"
                 title="刪除此會員">
                 <i class="far fa-trash-alt" aria-hidden="true"></i>
               </button>
             </td>
+            {{!--detail product modal --}}
+            <div class="modal fade orderModal{{this.id}}" tabindex="-1" role="dialog">
+              <div class="modal-dialog modal-lg" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title">#{{this.id}} / SN {{this.sn}}</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </div>
+                  <div class="modal-body">
+                    <div class="row col-11">
+                      <div class="col-md-7 item-title">商品{{cartProducts.length}}</div>
+                      <div class="col-md-5 item-title">
+                        <div class="d-flex justify-content-between align-items-center">
+                          <span>商品價格</span>
+                          <span>數量</span>
+                          <span>合計價格</span>
+                        </div>
+                      </div>
+                    </div>
+                    <hr>
+                    <div>
+                      {{#each this.products}}
+                        <div class="row col-11">
+                          <div class="row col-7">
+                            <a href="/products/{{this.id}}" class="product-img">
+                              <img src="{{this.mainImg}}" class="rounded mx-auto d-block" alt="productImage"
+                                style="height:50px">
+                            </a>
+                            <div class="col-md-7 item-title">{{this.name}}</div>
+                          </div>
+                          <div class="col-md-5 font-format">
+                            <div class="d-flex justify-content-between align-items-center">
+                              <span>NTD {{this.price}}</span>
+                              <span>
+                                <div class="d-flex align-items-center item-quantity">
+                                  <span class="px-3">
+                                    {{this.OrderItem.quantity}}
+                                  </span>
+                                </div>
+                              </span>
+                              <span>
+                                <div class="d-flex align-items-center item-quantity">
+                                  <span class="px-3">
+                                    NTD {{this.subPrice}}
+                                  </span>
+                                </div>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <hr>
+                      {{/each}}
+                    </div>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn font-weight-normal">
+                      <a href="/admin/products/{{this.id}}/edit" class="btn btn-primary">編輯此商品</a>
+                    </button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                  </div>
+                </div>
+              </div>
+            </div>
         {{/each}}
       </tbody>
     </table>

--- a/views/admin/orders.hbs
+++ b/views/admin/orders.hbs
@@ -1,0 +1,84 @@
+<main class="container">
+  <div class="card-body pt-4">
+    <table data-toggle="table" data-search="true" data-show-columns="true" data-pagination="true" id="table">
+      <thead>
+        <tr>
+          <th data-valign="middle" class="text-center" data-sortable="true">#</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">SN</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">成立時間</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">總金額</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">付款方式</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">付款狀態</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">出貨狀態</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">會員帳號</th>
+          {{!-- <th data-valign="middle" class="text-center" data-sortable="true">收件人</th>
+          <th data-valign="middle" class="text-center" data-sortable="true" data-width="150">收件地址</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">聯絡電話</th> --}}
+          <th data-valign="middle" class="text-center">會員操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each orders}}
+          <tr>
+            <td>{{this.id}}</td>
+            <td>{{this.sn}}</td>
+            <td>{{this.createdTime}}</td>
+            <td>{{this.amount}}</td>
+            <td>{{this.payMethod}}</td>
+            <td>
+              {{#if this.payStatus}}
+                <i class="fas fa-check text-success"></i>
+              {{else}}
+                <i class="fas fa-times text-danger"></i>
+              {{/if}}
+            </td>
+            <td>
+              {{#if this.shipStatus}}
+                <i class="fas fa-check text-success"></i>
+              {{else}}
+                <i class="fas fa-times text-danger"></i>
+              {{/if}}
+            </td>
+            <td>{{this.User.email}}</td>
+            {{!-- <td>{{this.receiver}}</td>
+            <td>{{this.address}}</td>
+            <td>{{this.phone}}</td> --}}
+            {{!-- <td>
+              {{#ifEqual this.gender 'M'}}<i class="fas fa-mars text-primary"></i>{{/ifEqual}}
+              {{#ifEqual this.gender 'F'}}<i class="fas fa-venus text-danger"></i>{{/ifEqual}}
+            </td>
+            <td>
+              {{#if this.orderCount}}
+                {{this.orderCount}}
+              {{else}}
+                -
+              {{/if}}
+            </td>
+            <td>
+              {{#if this.isAdmin}}
+                <i class="fas fa-check text-success"></i>
+              {{else}}
+                <i class="fas fa-times text-danger"></i>
+              {{/if}}
+            </td> --}}
+            <td>
+              <button type="button" class="btn font-weight-normal">
+                <a href="/admin/user/{{this.id}}/edit " class="text-decoration-none text-dark "><i class="fas fa-edit"
+                    title="編輯會員資料"></i></a>
+              </button>
+              <button type="button" class="btn font-weight-normal">
+                <a href="#" target="_blank" class="text-decoration-none text-dark ">
+                  <i class="fas fa-search-plus" title="詳細資料"></i>
+                </a>
+              </button>
+              <!-- Delete Button trigger modal -->
+              <button type="button" class="btn font-weight-normal" data-toggle="modal" data-target="#delete_{{this.id}}"
+                title="刪除此會員">
+                <i class="far fa-trash-alt" aria-hidden="true"></i>
+              </button>
+            </td>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+</main>

--- a/views/admin/orders.hbs
+++ b/views/admin/orders.hbs
@@ -62,17 +62,13 @@
               {{/if}}
             </td> --}}
             <td>
-              <button type="button" class="btn font-weight-normal">
-                <a href="/admin/user/{{this.id}}/edit " class="text-decoration-none text-dark "><i class="fas fa-edit"
-                    title="編輯會員資料"></i></a>
-              </button>
-              <button type="button" class="btn font-weight-normal">
-                <a href="#" target="_blank" class="text-decoration-none text-dark ">
-                  <i class="fas fa-search-plus" title="詳細資料"></i>
-                </a>
-              </button>
+              <a href="/admin/user/{{this.id}}/edit " class="btn btn-outline-dark mr-1"><i class="fas fa-edit"
+                  title="編輯會員資料"></i></a>
+              <a href="#" target="_blank" class="btn btn-outline-dark mr-1">
+                <i class="fas fa-search-plus" title="詳細資料"></i>
+              </a>
               <!-- Delete Button trigger modal -->
-              <button type="button" class="btn font-weight-normal" data-toggle="modal" data-target="#delete_{{this.id}}"
+              <button type="button" class="btn btn-outline-dark" data-toggle="modal" data-target="#delete_{{this.id}}"
                 title="刪除此會員">
                 <i class="far fa-trash-alt" aria-hidden="true"></i>
               </button>

--- a/views/admin/orders.hbs
+++ b/views/admin/orders.hbs
@@ -11,10 +11,7 @@
           <th data-valign="middle" class="text-center" data-sortable="true">付款狀態</th>
           <th data-valign="middle" class="text-center" data-sortable="true">出貨狀態</th>
           <th data-valign="middle" class="text-center" data-sortable="true">會員帳號</th>
-          {{!-- <th data-valign="middle" class="text-center" data-sortable="true">收件人</th>
-          <th data-valign="middle" class="text-center" data-sortable="true" data-width="150">收件地址</th>
-          <th data-valign="middle" class="text-center" data-sortable="true">聯絡電話</th> --}}
-          <th data-valign="middle" class="text-center">會員操作</th>
+          <th data-valign="middle" class="text-center">訂單操作</th>
         </tr>
       </thead>
       <tbody>
@@ -41,10 +38,9 @@
             </td>
             <td>{{this.User.email}}</td>
             <td>
-              <a href="/admin/user/{{this.id}}/edit " class="btn btn-outline-dark mr-1"><i class="fas fa-edit"
-                  title="編輯會員資料"></i></a>
+              {{!--detail Button trigger modal --}}
               <button type="button" class="btn btn-outline-dark mr-1" data-toggle="modal"
-                data-target=".orderModal{{this.id}}"><i class="fas fa-search-plus" title="訂單詳情"></i></button>
+                data-target=".orderModal{{this.id}}"><i class="fas fa-search-plus" title="出貨詳情"></i></button>
               <!-- Delete Button trigger modal -->
               <button type="button" class="btn btn-outline-dark" data-toggle="modal" data-target="#delete_{{this.id}}"
                 title="刪除此會員">
@@ -62,10 +58,22 @@
                     </button>
                   </div>
                   <div class="modal-body">
-                    <div class="row col-11">
-                      <div class="col-md-7 item-title">商品{{cartProducts.length}}</div>
-                      <div class="col-md-5 item-title">
-                        <div class="d-flex justify-content-between align-items-center">
+                    <div class="row col-12">
+                      <div class="col-6">
+                        <p>收件人：{{this.receiver}}</p>
+                      </div>
+                      <div class="col-6">
+                        <p>聯絡電話：{{this.phone}}</p>
+                      </div>
+                      <div class="col-12">
+                        <p class="mb-0">收件地址：{{this.address}}</p>
+                      </div>
+                    </div>
+                    <hr>
+                    <div class="row col-12">
+                      <div class="col-7 text-center">商品{{cartProducts.length}}</div>
+                      <div class="col-5 text-center">
+                        <div class="d-flex justify-content-between">
                           <span>商品價格</span>
                           <span>數量</span>
                           <span>合計價格</span>
@@ -75,27 +83,27 @@
                     <hr>
                     <div>
                       {{#each this.products}}
-                        <div class="row col-11">
-                          <div class="row col-7">
+                        <div class="row col-12">
+                          <div class="row col-7 pl-5 text-center">
                             <a href="/products/{{this.id}}" class="product-img">
                               <img src="{{this.mainImg}}" class="rounded mx-auto d-block" alt="productImage"
                                 style="height:50px">
                             </a>
-                            <div class="col-md-7 item-title">{{this.name}}</div>
+                            <div class="col-md-7">{{this.name}}</div>
                           </div>
-                          <div class="col-md-5 font-format">
-                            <div class="d-flex justify-content-between align-items-center">
-                              <span>NTD {{this.price}}</span>
+                          <div class="col-5 text-center ml-4 pr-0">
+                            <div class="d-flex justify-content-between">
+                              <span class="mr-5">NTD {{this.price}}</span>
                               <span>
-                                <div class="d-flex align-items-center item-quantity">
-                                  <span class="px-3">
+                                <div class="d-flex align-items-center">
+                                  <span class="pr-4">
                                     {{this.OrderItem.quantity}}
                                   </span>
                                 </div>
                               </span>
                               <span>
-                                <div class="d-flex align-items-center item-quantity">
-                                  <span class="px-3">
+                                <div class="d-flex align-items-center">
+                                  <span class="pl-3">
                                     NTD {{this.subPrice}}
                                   </span>
                                 </div>
@@ -105,12 +113,16 @@
                         </div>
                         <hr>
                       {{/each}}
+                      <div class="row col-12">
+                        <div class="col-9"></div>
+                        <div class="col-3 d-flex justify-content-between align-items-center pr-0">
+                          <span>總價：</span>
+                          <span class="font-weight-bold pr-1">NTD {{this.amount}}</span>
+                        </div>
+                      </div>
                     </div>
                   </div>
                   <div class="modal-footer">
-                    <button type="button" class="btn font-weight-normal">
-                      <a href="/admin/products/{{this.id}}/edit" class="btn btn-primary">編輯此商品</a>
-                    </button>
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                   </div>
                 </div>

--- a/views/admin/users.hbs
+++ b/views/admin/users.hbs
@@ -26,7 +26,13 @@
               {{#ifEqual this.gender 'M'}}<i class="fas fa-mars text-primary"></i>{{/ifEqual}}
               {{#ifEqual this.gender 'F'}}<i class="fas fa-venus text-danger"></i>{{/ifEqual}}
             </td>
-            <td></td>
+            <td>
+              {{#if this.orderCount}}
+                {{this.orderCount}}
+              {{else}}
+                -
+              {{/if}}
+            </td>
             <td>
               {{#if this.isAdmin}}
                 <i class="fas fa-check text-success"></i>


### PR DESCRIPTION

<img width="1440" alt="螢幕快照 2020-01-01 下午5 22 20" src="https://user-images.githubusercontent.com/49901777/71639907-541e4d80-2cbb-11ea-8383-23c446098af5.png">

- 完成後台訂單資料頁面
- 比照後台商品頁面製作
- 表格內僅呈現較簡易資訊
- 詳細出貨資訊(收件資訊＆商品資訊)收納於modal中，類似出貨單方式呈現
<img width="1440" alt="螢幕快照 2020-01-01 下午5 22 34" src="https://user-images.githubusercontent.com/49901777/71639911-597b9800-2cbb-11ea-8094-4b6c08b5c576.png">

## 手動確認目標
- 登入管理者帳號，於後台navbar選擇訂單可連至此頁面
- 表格內資料與資料庫中資料一致
- 出貨詳細按鈕點擊後會顯示出貨相關資訊
- 出貨相關資訊與資料庫中資料一致
