### PR TITLE
【加入】結帳頁-2、delivery 交貨頁

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ app.use(flash())
 app.use(session({
   secret: 'LastWendyTomatoBurger',
   name: 'greatSmile',
-  cookie: { maxAge: 80000 },
+  cookie: { maxAge: 1000*60*10 },
   resave: false,
   saveUninitialized: false
 }))

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -1,0 +1,21 @@
+const db = require('../models')
+const Cart = db.Cart
+
+module.exports = {
+  async addressPage(req, res) {
+    try {
+      const cartId = req.session.cartId
+      const cart = await Cart.findByPk(cartId, {
+        include: 'products'
+      }) 
+
+      console.log(cart && cart.dataValues)
+
+      res.render('address', { css: 'address', cart })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  }
+}

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -38,5 +38,27 @@ module.exports = {
       console.error(err)
       res.status(500).json({ status: 'serverError', message: err.toString() })
     }
-  }
+  },
+
+  async address(req, res) {
+    try {
+
+      res.redirect('/order/delivery-method')
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  },
+
+  async deliveryPage(req, res) {
+    try {
+
+      res.render('delivery', { css: "delivery" })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  },
 }

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -40,17 +40,6 @@ module.exports = {
     }
   },
 
-  async address(req, res) {
-    try {
-
-      res.redirect('/order/delivery-method')
-
-    } catch (err) {
-      console.error(err)
-      res.status(500).json({ status: 'serverError', message: err.toString() })
-    }
-  },
-
   async deliveryPage(req, res) {
     try {
       const cartId = req.session.cartId

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -18,8 +18,16 @@ module.exports = {
         ]
       })
 
-      console.log(cart.products[0].CartItem)
-      res.render('address', { css: 'address', cart })
+      // 製作頁面資料
+      const products = (cart && cart.products) || []
+      let totalPrice = 0
+      products.forEach(prod => {
+        prod.quantity = prod.CartItem.quantity
+        prod.amount = (prod.price * prod.quantity)
+        totalPrice += prod.amount
+      })
+
+      res.render('address', { css: 'address', cart, totalPrice })
 
     } catch (err) {
       console.error(err)

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -81,7 +81,10 @@ module.exports = {
         totalPrice += prod.amount
       })
 
-      res.render('delivery', { css: "delivery", cart, totalPrice })
+      // 預設運費
+      const totalPrice2 = totalPrice + 150
+
+      res.render('delivery', { css: "delivery", cart, totalPrice, totalPrice2 })
 
     } catch (err) {
       console.error(err)

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -5,12 +5,20 @@ module.exports = {
   async addressPage(req, res) {
     try {
       const cartId = req.session.cartId
-      const cart = await Cart.findByPk(cartId, {
-        include: 'products'
-      }) 
+      const cart = await Cart.findByPk(1, {
+        include: [
+          { 
+            association: 'products',
+            attributes: ['id', 'name', 'price'],
+            include: [{
+              association: 'Images',
+              where: { is_main: true }
+            }],
+          }
+        ]
+      })
 
-      console.log(cart && cart.dataValues)
-
+      console.log(cart.products[0].CartItem)
       res.render('address', { css: 'address', cart })
 
     } catch (err) {

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -53,8 +53,35 @@ module.exports = {
 
   async deliveryPage(req, res) {
     try {
+      const cartId = req.session.cartId
+      const cart = await Cart.findByPk(cartId, {
+        include: [
+          {
+            association: 'products',
+            attributes: ['id', 'name', 'price'],
+            include: [{
+              association: 'Images',
+              where: { is_main: true }
+            }],
+          }
+        ]
+      })
 
-      res.render('delivery', { css: "delivery" })
+      // 確認有無選購商品
+      if (!cart || !cart.products.length) {
+        return res.redirect('/cart')
+      }
+
+      // 製作頁面資料
+      const products = cart.products
+      let totalPrice = 0
+      products.forEach(prod => {
+        prod.quantity = prod.CartItem.quantity
+        prod.amount = (prod.price * prod.quantity)
+        totalPrice += prod.amount
+      })
+
+      res.render('delivery', { css: "delivery", cart, totalPrice })
 
     } catch (err) {
       console.error(err)

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -5,7 +5,7 @@ module.exports = {
   async addressPage(req, res) {
     try {
       const cartId = req.session.cartId
-      const cart = await Cart.findByPk(1, {
+      const cart = await Cart.findByPk(cartId, {
         include: [
           { 
             association: 'products',
@@ -18,8 +18,13 @@ module.exports = {
         ]
       })
 
+      // 確認有無選購商品
+      if (!cart || !cart.products.length) {
+        return res.redirect('/cart')
+      } 
+
       // 製作頁面資料
-      const products = (cart && cart.products) || []
+      const products = cart.products
       let totalPrice = 0
       products.forEach(prod => {
         prod.quantity = prod.CartItem.quantity

--- a/lib/hbs_helpers.js
+++ b/lib/hbs_helpers.js
@@ -2,4 +2,8 @@ module.exports = {
   ifEqual: function (arg1, arg2, options) {
     return (arg1 === arg2) ? options.fn(this) : options.inverse(this)
   },
+
+  addDot: function (arg1) {
+    return arg1.toLocaleString()
+  }
 }

--- a/lib/hbs_helpers.js
+++ b/lib/hbs_helpers.js
@@ -4,6 +4,6 @@ module.exports = {
   },
 
   addDot: function (arg1) {
-    return arg1.toLocaleString()
+    return arg1 && arg1.toLocaleString()
   }
 }

--- a/public/css/address.css
+++ b/public/css/address.css
@@ -1,0 +1,90 @@
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+}
+
+.panel {
+  border-radius: 20px;
+  background: #fff;
+}
+
+/* nav step */
+.step {
+  font-size: .9rem;
+}
+
+.step li {
+  border-top: 3px solid #eee;
+  color: #d6d6d6;
+  font-weight: bolder;
+}
+
+.step li.active {
+  border-top: 3px solid #ff9400;
+  color: #000;
+  font-weight: normal;
+}
+
+/* form */
+.font-small {
+  font-size: .85rem;
+}
+
+.font-smaller {
+  font-size: .7rem;
+}
+
+.form-row [class*='col'] {
+  margin: 0 0 .75rem 0;
+}
+
+.form-row input {
+  display: block;
+  background: #f8f5f1;
+  border: 1px solid #e0dbd3;
+  padding: .3rem;
+  border-radius: 5px;
+  width: 100%;
+}
+
+.order-btn {
+  display: inline-block;
+  background: #ff5400;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 10px;
+  padding: 1rem 1.5rem;
+  font-size: 1rem;
+}
+
+/* aside */
+aside .panel {
+  box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, .25);
+}
+
+.prod-list .row {
+  margin: 0;
+  padding: 1rem 0;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.prod-list .row:nth-last-child(1) {
+  border-bottom: 0;
+}
+
+.prod-list img {
+  width: 52px;
+  height: 52px;
+  padding: 2px;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: .25rem;
+}
+
+.prod-list a {
+  color: #000;
+}
+
+.prod-list a:hover {
+  color: #2a6496;;
+  text-decoration: none;
+}

--- a/public/css/delivery.css
+++ b/public/css/delivery.css
@@ -56,6 +56,32 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 1rem;
 }
 
+/* input radio */
+.radio-label::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0.2rem;
+  left: -0.2rem;
+  width: 20px;
+  height: 20px;
+  background: #f0ebe5;
+  border: 2px solid #e0dbd3;
+  border-radius: 50%;
+}
+
+input[type=radio]:checked+label::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0.3rem;
+  left: -0.1rem;
+  width: 17px;
+  height: 17px;
+  border: 5px solid #ff9600;
+  border-radius: 50%;
+}
+
 /* aside */
 aside .panel {
   box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, .25);

--- a/public/css/delivery.css
+++ b/public/css/delivery.css
@@ -1,0 +1,90 @@
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+}
+
+.panel {
+  border-radius: 20px;
+  background: #fff;
+}
+
+/* nav step */
+.step {
+  font-size: .9rem;
+}
+
+.step li {
+  border-top: 3px solid #eee;
+  color: #d6d6d6;
+  font-weight: bolder;
+}
+
+.step li.active {
+  border-top: 3px solid #ff9400;
+  color: #000;
+  font-weight: normal;
+}
+
+/* form */
+.font-small {
+  font-size: .85rem;
+}
+
+.font-smaller {
+  font-size: .7rem;
+}
+
+.form-row [class*='col'] {
+  margin: 0 0 .75rem 0;
+}
+
+.form-row input {
+  display: block;
+  background: #f8f5f1;
+  border: 1px solid #e0dbd3;
+  padding: .3rem;
+  border-radius: 5px;
+  width: 100%;
+}
+
+.order-btn {
+  display: inline-block;
+  background: #ff5400;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 10px;
+  padding: 1rem 1.5rem;
+  font-size: 1rem;
+}
+
+/* aside */
+aside .panel {
+  box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, .25);
+}
+
+.prod-list .row {
+  margin: 0;
+  padding: 1rem 0;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.prod-list .row:nth-last-child(1) {
+  border-bottom: 0;
+}
+
+.prod-list img {
+  width: 52px;
+  height: 52px;
+  padding: 2px;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: .25rem;
+}
+
+.prod-list a {
+  color: #000;
+}
+
+.prod-list a:hover {
+  color: #2a6496;;
+  text-decoration: none;
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -57,18 +57,18 @@ body {
   color:#ffffff;
 }
 
-.navbar {
+.category-bar .navbar {
   padding-right: 0;
   padding-left: 0;
 }
 
-.nav-link {
+.category-bar .nav-link {
   color: #ffffff;
   display: block;
-  text-decoration:none;
+  text-decoration: none;
 }
 
-.nav-link:hover{
+.category-bar .nav-link:hover{
   background-color:#eee;
   color:#454545;
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,6 +10,7 @@ module.exports = app => {
   app.use('/', getCartItem)  // 請勿更動順序
   app.use('/products', require('./products.js'))
   app.use('/cart', require('./cart.js'))
+  app.use('/order', require('./order.js'))
   app.use('/users', require('./users.js'))
   app.use('/admin', require('./admin/index.js'))
 

--- a/routes/order.js
+++ b/routes/order.js
@@ -1,0 +1,7 @@
+const router = require('express').Router()
+const orderCtrller = require('../controllers/orderCtrller.js')
+
+// route base '/order'
+router.get('/', orderCtrller.addressPage)
+
+module.exports = router

--- a/routes/order.js
+++ b/routes/order.js
@@ -3,5 +3,7 @@ const orderCtrller = require('../controllers/orderCtrller.js')
 
 // route base '/order'
 router.get('/', orderCtrller.addressPage)
+router.post('/', orderCtrller.address)
+router.get('/delivery-method', orderCtrller.deliveryPage)
 
 module.exports = router

--- a/routes/order.js
+++ b/routes/order.js
@@ -3,7 +3,6 @@ const orderCtrller = require('../controllers/orderCtrller.js')
 
 // route base '/order'
 router.get('/', orderCtrller.addressPage)
-router.post('/', orderCtrller.address)
 router.get('/delivery-method', orderCtrller.deliveryPage)
 
 module.exports = router

--- a/views/address.hbs
+++ b/views/address.hbs
@@ -75,11 +75,11 @@
         <div class="px-3 pb-3">
           <div class="d-flex justify-content-between border-bottom py-2 font-small">
             <span>小計:</span>
-            <span>NTD 1,000</span>
+            <span>NTD {{addDot totalPrice}}</span>
           </div>
           <div class="d-flex justify-content-between font-weight-bold py-2">
             <span>合計:</span>
-            <span>NTD 1,000</span>
+            <span>NTD {{addDot totalPrice}}</span>
           </div>
         </div>
       </section>
@@ -100,8 +100,8 @@
                 </a>
                 <div class="font-smaller">
                   <div class="w-50 ml-auto text-left">
-                    <p>NTD {{price}} x {{CartItem.quantity}} =</p>
-                    <p class="font-weight-bold">NTD 1,000</p>
+                    <p>NTD {{addDot price}} x {{addDot quantity}} =</p>
+                    <p class="font-weight-bold">NTD {{addDot amount}}</p>
                   </div>
                 </div>
               </div>

--- a/views/address.hbs
+++ b/views/address.hbs
@@ -20,7 +20,7 @@
           </section>
           <section class="col-8">
             <div class="col-10">
-              <form action="#" method="POST">
+              <form action="/order" method="POST">
                 <div class="form-row row-cols-2">
                   <div class="col mb-0">
                     <input type="text" name="lastName" placeholder="姓氏*">

--- a/views/address.hbs
+++ b/views/address.hbs
@@ -20,7 +20,7 @@
           </section>
           <section class="col-8">
             <div class="col-10">
-              <form action="/order" method="POST">
+              <form action="/order/delivery-method" method="GET">
                 <div class="form-row row-cols-2">
                   <div class="col mb-0">
                     <input type="text" name="lastName" placeholder="姓氏*">

--- a/views/address.hbs
+++ b/views/address.hbs
@@ -1,0 +1,133 @@
+<div class="container py-5">
+  <div class="row">
+    {{!-- 主內容 --}}
+    <main class="col-8" role="main">
+      <section class="panel">
+        {{!-- 結帳步驟 step nav --}}
+        <nav class="step border-bottom px-2">
+          <ul class="nav justify-content-around">
+            <li class="px-4 py-3 active">1.收件地址</li>
+            <li class="px-4 py-3">2.寄件方式</li>
+            <li class="px-4 py-3">3.付款&帳單</li>
+            <li class="px-4 py-3">4.最後檢視</li>
+          </ul>
+        </nav>
+        {{!-- 內容表單 --}}
+        <div class="row p-4">
+          <section class="col-4">
+            <h6 class="mb-4 font-weight-bold">選擇地址</h6>
+            <p class="font-small">請從你的地址清單中選擇一處，或輸入新地址</p>
+          </section>
+          <section class="col-8">
+            <div class="col-10">
+              <form action="#" method="POST">
+                <div class="form-row row-cols-2">
+                  <div class="col mb-0">
+                    <input type="text" name="lastName" placeholder="姓氏*">
+                  </div>
+                  <div class="col mb-0">
+                    <input type="text" name="firstName" placeholder="名子*">
+                  </div>
+                  <div class="col-12 mb-4">
+                    <span class="font-small text-danger">收件地址請使用繁體中文</span>
+                  </div>
+                  <div class="col">
+                    <input type="text" name="postCode" placeholder="郵遞區號*">
+                  </div>
+                  <div class="col"></div>
+                  <div class="col">
+                    <input type="text" name="region" placeholder="縣市*">
+                  </div>
+                  <div class="col">
+                    <input type="text" name="townCity" placeholder="鄉鎮市區*">
+                  </div>
+                  <div class="col-12">
+                    <input type="text" name="line1" placeholder="街道地址*">
+                  </div>
+                  <div class="col-12 mb-0">
+                    <input type="text" name="line2" placeholder="大樓名, 房號等">
+                  </div>
+                  <div class="col-12 mb-4">
+                    <span class="font-small text-danger">※收件地址請使用繁體中文</span>
+                  </div>
+                  <div class="col-12 mb-0">
+                    <input type="text" name="phone" placeholder="手機號碼*">
+                  </div>
+                </div>
+                <div class="form-check my-4">
+                  <label class="form-check-label">
+                    <input class="form-check-input" name="saveAddress" type="checkbox">
+                    <span>儲存收件地址</span>
+                  </label>
+                </div>
+                <button class="btn order-btn">下一步</button>
+              </form>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+    {{!-- 側邊攔 --}}
+    <aside class="col-4">
+      {{!-- 總金額 --}}
+      <section class="panel mb-4">
+        <h6 class="font-weight-bold border-bottom p-3">訂單合計</h6>
+        <div class="px-3 pb-3">
+          <div class="d-flex justify-content-between border-bottom py-2 font-small">
+            <span>小計:</span>
+            <span>NTD 1,000</span>
+          </div>
+          <div class="d-flex justify-content-between font-weight-bold py-2">
+            <span>合計:</span>
+            <span>NTD 1,000</span>
+          </div>
+        </div>
+      </section>
+      {{!-- 產品 --}}
+      <section class="panel">
+        <h6 class="font-weight-bold border-bottom p-3">配送商品</h6>
+        <div class="prod-list px-3">
+
+          <div class="row">
+            <div class="col-2 px-0">
+              <a href="#">
+                <img src="https://via.placeholder.com/150" alt="product-img">
+              </a>
+            </div>
+            <div class="col-10 pl-2">
+              <a href="#">
+                <h6 class="mb-3">Product name</h6>
+              </a>
+              <div class="font-smaller">
+                <div class="w-50 ml-auto text-left">
+                  <p>NTD 1,000 x 1 =</p>
+                  <p class="font-weight-bold">NTD 1,000</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-2 px-0">
+              <a href="#">
+                <img src="https://via.placeholder.com/150" alt="product-img">
+              </a>
+            </div>
+            <div class="col-10 pl-2">
+              <a href="#">
+                <h6 class="mb-3">Product name</h6>
+              </a>
+              <div class="font-smaller">
+                <div class="w-50 ml-auto text-left">
+                  <p>NTD 1,000 x 1 =</p>
+                  <p class="font-weight-bold">NTD 1,000</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          
+        </div>
+      </section>
+    </aside>
+  </div>
+</div>

--- a/views/address.hbs
+++ b/views/address.hbs
@@ -87,45 +87,26 @@
       <section class="panel">
         <h6 class="font-weight-bold border-bottom p-3">配送商品</h6>
         <div class="prod-list px-3">
-
-          <div class="row">
-            <div class="col-2 px-0">
-              <a href="#">
-                <img src="https://via.placeholder.com/150" alt="product-img">
-              </a>
-            </div>
-            <div class="col-10 pl-2">
-              <a href="#">
-                <h6 class="mb-3">Product name</h6>
-              </a>
-              <div class="font-smaller">
-                <div class="w-50 ml-auto text-left">
-                  <p>NTD 1,000 x 1 =</p>
-                  <p class="font-weight-bold">NTD 1,000</p>
+          {{#each cart.products}}
+            <div class="row">
+              <div class="col-2 px-0">
+                <a href="/products/{{id}}">
+                  <img src="{{Images.0.url}}" alt="product-img">
+                </a>
+              </div>
+              <div class="col-10 pl-2">
+                <a href="/products/{{id}}">
+                  <h6 class="mb-3">{{name}}</h6>
+                </a>
+                <div class="font-smaller">
+                  <div class="w-50 ml-auto text-left">
+                    <p>NTD {{price}} x {{CartItem.quantity}} =</p>
+                    <p class="font-weight-bold">NTD 1,000</p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-
-          <div class="row">
-            <div class="col-2 px-0">
-              <a href="#">
-                <img src="https://via.placeholder.com/150" alt="product-img">
-              </a>
-            </div>
-            <div class="col-10 pl-2">
-              <a href="#">
-                <h6 class="mb-3">Product name</h6>
-              </a>
-              <div class="font-smaller">
-                <div class="w-50 ml-auto text-left">
-                  <p>NTD 1,000 x 1 =</p>
-                  <p class="font-weight-bold">NTD 1,000</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          
+          {{/each}}
         </div>
       </section>
     </aside>

--- a/views/cart.hbs
+++ b/views/cart.hbs
@@ -129,7 +129,7 @@
       <div class="row panel mx-1 font-format" >
         <div class="panel-body w-100 p-3">
           <div class="checkout pb-1">
-            <a href="#" class="cart-btn btn w-100">
+            <a href="/order" class="cart-btn btn w-100">
               <i class="fas fa-cart-arrow-down"></i>
               <span>　前往結帳</span>
             </a>

--- a/views/delivery.hbs
+++ b/views/delivery.hbs
@@ -1,0 +1,114 @@
+<div class="container py-5">
+  <div class="row">
+    {{!-- 主內容 --}}
+    <main class="col-8" role="main">
+      <section class="panel">
+        {{!-- 結帳步驟 step nav --}}
+        <nav class="step border-bottom px-2">
+          <ul class="nav justify-content-around">
+            <li class="px-4 py-3 active">1.收件地址</li>
+            <li class="px-4 py-3">2.寄件方式</li>
+            <li class="px-4 py-3">3.付款&帳單</li>
+            <li class="px-4 py-3">4.最後檢視</li>
+          </ul>
+        </nav>
+        {{!-- 內容表單 --}}
+        <div class="row p-4">
+          <section class="col-4">
+            <h6 class="mb-4 font-weight-bold">選擇地址</h6>
+            <p class="font-small">請從你的地址清單中選擇一處，或輸入新地址</p>
+          </section>
+          <section class="col-8">
+            <div class="col-10">
+              <form action="/order" method="POST">
+                <div class="form-row row-cols-2">
+                  <div class="col mb-0">
+                    <input type="text" name="lastName" placeholder="姓氏*">
+                  </div>
+                  <div class="col mb-0">
+                    <input type="text" name="firstName" placeholder="名子*">
+                  </div>
+                  <div class="col-12 mb-4">
+                    <span class="font-small text-danger">收件地址請使用繁體中文</span>
+                  </div>
+                  <div class="col">
+                    <input type="text" name="postCode" placeholder="郵遞區號*">
+                  </div>
+                  <div class="col"></div>
+                  <div class="col">
+                    <input type="text" name="region" placeholder="縣市*">
+                  </div>
+                  <div class="col">
+                    <input type="text" name="townCity" placeholder="鄉鎮市區*">
+                  </div>
+                  <div class="col-12">
+                    <input type="text" name="line1" placeholder="街道地址*">
+                  </div>
+                  <div class="col-12 mb-0">
+                    <input type="text" name="line2" placeholder="大樓名, 房號等">
+                  </div>
+                  <div class="col-12 mb-4">
+                    <span class="font-small text-danger">※收件地址請使用繁體中文</span>
+                  </div>
+                  <div class="col-12 mb-0">
+                    <input type="text" name="phone" placeholder="手機號碼*">
+                  </div>
+                </div>
+                <div class="form-check my-4">
+                  <label class="form-check-label">
+                    <input class="form-check-input" name="saveAddress" type="checkbox">
+                    <span>儲存收件地址</span>
+                  </label>
+                </div>
+                <button class="btn order-btn">下一步</button>
+              </form>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+    {{!-- 側邊攔 --}}
+    <aside class="col-4">
+      {{!-- 總金額 --}}
+      <section class="panel mb-4">
+        <h6 class="font-weight-bold border-bottom p-3">訂單合計</h6>
+        <div class="px-3 pb-3">
+          <div class="d-flex justify-content-between border-bottom py-2 font-small">
+            <span>小計:</span>
+            <span>NTD {{addDot totalPrice}}</span>
+          </div>
+          <div class="d-flex justify-content-between font-weight-bold py-2">
+            <span>合計:</span>
+            <span>NTD {{addDot totalPrice}}</span>
+          </div>
+        </div>
+      </section>
+      {{!-- 產品 --}}
+      <section class="panel">
+        <h6 class="font-weight-bold border-bottom p-3">配送商品</h6>
+        <div class="prod-list px-3">
+          {{#each cart.products}}
+            <div class="row">
+              <div class="col-2 px-0">
+                <a href="/products/{{id}}">
+                  <img src="{{Images.0.url}}" alt="product-img">
+                </a>
+              </div>
+              <div class="col-10 pl-2">
+                <a href="/products/{{id}}">
+                  <h6 class="mb-3">{{name}}</h6>
+                </a>
+                <div class="font-smaller">
+                  <div class="w-50 ml-auto text-left">
+                    <p>NTD {{addDot price}} x {{addDot quantity}} =</p>
+                    <p class="font-weight-bold">NTD {{addDot amount}}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          {{/each}}
+        </div>
+      </section>
+    </aside>
+  </div>
+</div>

--- a/views/delivery.hbs
+++ b/views/delivery.hbs
@@ -6,8 +6,8 @@
         {{!-- 結帳步驟 step nav --}}
         <nav class="step border-bottom px-2">
           <ul class="nav justify-content-around">
-            <li class="px-4 py-3 active">1.收件地址</li>
-            <li class="px-4 py-3">2.寄件方式</li>
+            <li class="px-4 py-3">1.收件地址</li>
+            <li class="px-4 py-3 active">2.寄件方式</li>
             <li class="px-4 py-3">3.付款&帳單</li>
             <li class="px-4 py-3">4.最後檢視</li>
           </ul>
@@ -15,50 +15,26 @@
         {{!-- 內容表單 --}}
         <div class="row p-4">
           <section class="col-4">
-            <h6 class="mb-4 font-weight-bold">選擇地址</h6>
-            <p class="font-small">請從你的地址清單中選擇一處，或輸入新地址</p>
+            <h6 class="mb-4 font-weight-bold">選擇寄件方式</h6>
           </section>
           <section class="col-8">
             <div class="col-10">
-              <form action="/order" method="POST">
-                <div class="form-row row-cols-2">
-                  <div class="col mb-0">
-                    <input type="text" name="lastName" placeholder="姓氏*">
-                  </div>
-                  <div class="col mb-0">
-                    <input type="text" name="firstName" placeholder="名子*">
-                  </div>
-                  <div class="col-12 mb-4">
-                    <span class="font-small text-danger">收件地址請使用繁體中文</span>
-                  </div>
-                  <div class="col">
-                    <input type="text" name="postCode" placeholder="郵遞區號*">
-                  </div>
-                  <div class="col"></div>
-                  <div class="col">
-                    <input type="text" name="region" placeholder="縣市*">
-                  </div>
-                  <div class="col">
-                    <input type="text" name="townCity" placeholder="鄉鎮市區*">
-                  </div>
-                  <div class="col-12">
-                    <input type="text" name="line1" placeholder="街道地址*">
-                  </div>
-                  <div class="col-12 mb-0">
-                    <input type="text" name="line2" placeholder="大樓名, 房號等">
-                  </div>
-                  <div class="col-12 mb-4">
-                    <span class="font-small text-danger">※收件地址請使用繁體中文</span>
-                  </div>
-                  <div class="col-12 mb-0">
-                    <input type="text" name="phone" placeholder="手機號碼*">
-                  </div>
-                </div>
-                <div class="form-check my-4">
-                  <label class="form-check-label">
-                    <input class="form-check-input" name="saveAddress" type="checkbox">
-                    <span>儲存收件地址</span>
+              <form action="#" method="GET">
+                <div class="form-check mb-2">
+                  <input id="radio1" class="form-check-input" type="radio" name="delivery_method" value="option1">
+                  <label class="form-check-label radio-label" for="radio1">
+                    <span>便利商店取貨 - NTD 80</span>
                   </label>
+                </div>
+                <div class="form-check mb-2">
+                  <input id="radio2" class="form-check-input" type="radio" name="delivery_method" value="option2">
+                  <label class="form-check-label radio-label" for="radio2">
+                    <span>宅配 - NTD 150</span>
+                  </label>
+                </div>
+                <div class="text-danger mb-4">
+                  <p>※顧客可能無法選擇所偏好的快遞公司。</p>
+                  <p>※所有寄件後的稅金及費用由顧客承擔。</p>
                 </div>
                 <button class="btn order-btn">下一步</button>
               </form>
@@ -75,6 +51,10 @@
         <div class="px-3 pb-3">
           <div class="d-flex justify-content-between border-bottom py-2 font-small">
             <span>小計:</span>
+            <span>NTD {{addDot totalPrice}}</span>
+          </div>
+          <div class="d-flex justify-content-between border-bottom py-2 font-small">
+            <span>運費:</span>
             <span>NTD {{addDot totalPrice}}</span>
           </div>
           <div class="d-flex justify-content-between font-weight-bold py-2">

--- a/views/delivery.hbs
+++ b/views/delivery.hbs
@@ -27,7 +27,7 @@
                   </label>
                 </div>
                 <div class="form-check mb-2">
-                  <input id="radio2" class="form-check-input" type="radio" name="delivery_method" value="option2">
+                  <input id="radio2" class="form-check-input" type="radio" name="delivery_method" value="option2" checked>
                   <label class="form-check-label radio-label" for="radio2">
                     <span>宅配 - NTD 150</span>
                   </label>
@@ -55,11 +55,11 @@
           </div>
           <div class="d-flex justify-content-between border-bottom py-2 font-small">
             <span>運費:</span>
-            <span>NTD {{addDot totalPrice}}</span>
+            <span>NTD 150</span>
           </div>
           <div class="d-flex justify-content-between font-weight-bold py-2">
             <span>合計:</span>
-            <span>NTD {{addDot totalPrice}}</span>
+            <span>NTD {{addDot totalPrice2}}</span>
           </div>
         </div>
       </section>


### PR DESCRIPTION
<img src="https://i.gyazo.com/7d1d62c26a426700a2b889b631b2dd56.png" width="500px">

完成交貨方式選擇頁面之 UI 切版。

## 確認目標
- 可從結帳頁-1，地址頁面，按「下一步」 GET 交貨頁
- 側邊攔能正確顯示購物車內商品
  - controller 內容基本是 adress 頁直接複製貼上，側邊攔應該沒問題
  - 合計部分，追加運費，目前先綁死「宅配」 NTD 150
    - (好微笑，並不會隨著選擇改變選擇，即時重新計算運費)
  - 目前合計數字為，小計 + $150
