### PR TITLE
【加入】使用者帳戶/訂單頁 

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ app.use((req, res, next) => {
   res.locals.success = req.flash('success')
   res.locals.error = req.flash('error')
   res.locals.user = req.user
+  res.locals.isAuthenticated = req.isAuthenticated()
   next()
 })
 

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -1,7 +1,7 @@
 const bcrypt = require('bcryptjs')
 const passport = require('passport')
 const db = require('../models')
-const { User } = db
+const { User, Order, Product } = db
 
 const { checkSignUp } = require('../lib/checker.js')
 
@@ -55,7 +55,34 @@ module.exports = {
     res.render('profile', { css: 'profile' })
   },
 
-  getOrders: (req, res) => {
-    res.render('orders', { css: 'profile' })
+  getOrders: async (req, res) => {
+    try {
+      let orders = await Order.findAll({
+        where: { user_id: req.user.id },
+        order: [['id', 'DESC']],
+        include: {
+          model: Product, as: 'products',
+          include: ['Gifts', 'Images']
+        }
+      })
+
+      orders.forEach(order => {
+        order.createdTime = order.createdAt.toJSON().split('T')[0]
+        order.amountFormat = order.amount.toLocaleString()
+        order.products.forEach(product => {
+          product.mainImg = product.Images.find(img => img.isMain).url
+          product.orderPrice = product.OrderItem.price.toLocaleString()
+          product.subPrice = product.OrderItem.quantity * product.price
+        })
+      })
+
+
+      res.render('orders', { orders, css: 'profile' })
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+
+
   },
 }

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -53,5 +53,9 @@ module.exports = {
 
   getProfile: (req, res) => {
     res.render('profile', { css: 'profile' })
-  }
+  },
+
+  getOrders: (req, res) => {
+    res.render('orders', { css: 'profile' })
+  },
 }

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -50,4 +50,8 @@ module.exports = {
     req.logout()
     res.redirect('/')
   },
+
+  getProfile: (req, res) => {
+    res.render('profile', { css: 'profile' })
+  }
 }

--- a/models/product.js
+++ b/models/product.js
@@ -34,8 +34,8 @@ module.exports = (sequelize, DataTypes) => {
     })
     Product.belongsToMany(models.Order, {
       through: models.OrderItem,
-      foreignKey: 'order_id',
-      as: 'orders'
+      foreignKey: 'product_id',
+      as: 'products'
     })
   };
   return Product;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -124,3 +124,11 @@ body {
   width: 70px;
   height: 70px;
 }
+
+.userpage-item {
+  font-size: 12px;
+}
+
+.userpage-link{
+  color: #49443f;
+}

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -74,3 +74,46 @@
 .side-list-text {
   font-size: 0.9rem;
 }
+
+.profile-href {
+  color: #258fb8;
+}
+
+.order-card {
+   cursor: pointer;
+   padding-left: 0;
+   padding-right: 0;
+   background-color: white;
+}
+
+.card{
+  width: 48rem;
+}
+
+.accordion-thead {
+  width: 16rem;
+  text-align: center;
+}
+
+.accordion-title {
+  width: 12rem;
+  padding-left: 5rem;
+  padding-right: 2rem;
+  text-align: right;
+}
+
+.accordion-data {
+  width: 30rem;
+}
+
+.border-less {
+  border-color: white;
+}
+
+.table th {
+  border-top: 0px;
+}
+
+.order-info {
+  font-size: 0.9rem;
+}

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -53,6 +53,10 @@
   font-size: 0.7rem;
 }
 
+.side-box-shadow {
+  box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, .25);
+}
+
 .tag-gift {
   background-color: #ffe14d;
   color: #e53900;
@@ -62,3 +66,4 @@
   background-color: #34A853;
   color: #ffffff;
 }
+

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -1,75 +1,3 @@
-.btn-sm {
-  line-height: .75rem;
-  padding: .25rem .35rem
-}
-
-.btn-outline-secondary {
-  border: 0;
-}
-
-.btn-outline-secondary:hover {
-  color: #454545;
-  font-weight: bold;
-  line-height: .75rem;
-  background-color: #f0ebe5;
-}
-
-.btn-unavailable.disabled, .btn-unavailable:hover {
-  opacity: 0.3;
-  font-weight: normal;
-  cursor: default;
-}
-
-.cart-amount {
-  margin: 0 18px;
-}
-
-.cart-btn {
-  display: inline-block;
-  background: #ff5400;
-  color: #fff;
-  font-weight: bold;
-  border-radius: 10px;
-  height: 69px;
-  line-height: 50px;
-}
-
-.cart-product {
-  margin: 0 18px 15px 18px;
-}
-
-.continue-btn a { 
-   background: #eeeeee;
-   color: #777;
-}
-
-.font-format {
-  color: #454545;
-  font-size: 12px;
-}
-
-.font-format-bold {
-  font-size: 13.2px;
-  font-weight: bold;
-}
-
-.img-fit {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.item-quantity {
-  background-color: #f0ebe5;
-  border: 1px solid #e0dbd3;
-  border-radius: 5px;
-}
-
-.item-title {
-  color: #727272;
-  font-size: 12px;
-  font-weight: bold;
-}
 
 .item-list {
   list-style:none;
@@ -109,33 +37,6 @@
 
 .panel-heading div {
   margin: 0 18px;
-}
-
-.product-btn {
-  color: #454545;
-  font-size: 14px;
-  cursor: pointer;
-}
-
-.product-btn:hover {
-  color: #2a6496;
-}
-
-.product-img {
-  width: 95px;
-  height: 120px;
-  background-color: #eee;
-  display: block;
-}
-
-.product-name {
-  font-size: 16px;
-}
-
-.product-tag {
-  font-weight: bold;
-  border-radius: 5px;
-  padding: 3px 6px;
 }
 
 .side-heading {

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -1,0 +1,163 @@
+.btn-sm {
+  line-height: .75rem;
+  padding: .25rem .35rem
+}
+
+.btn-outline-secondary {
+  border: 0;
+}
+
+.btn-outline-secondary:hover {
+  color: #454545;
+  font-weight: bold;
+  line-height: .75rem;
+  background-color: #f0ebe5;
+}
+
+.btn-unavailable.disabled, .btn-unavailable:hover {
+  opacity: 0.3;
+  font-weight: normal;
+  cursor: default;
+}
+
+.cart-amount {
+  margin: 0 18px;
+}
+
+.cart-btn {
+  display: inline-block;
+  background: #ff5400;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 10px;
+  height: 69px;
+  line-height: 50px;
+}
+
+.cart-product {
+  margin: 0 18px 15px 18px;
+}
+
+.continue-btn a { 
+   background: #eeeeee;
+   color: #777;
+}
+
+.font-format {
+  color: #454545;
+  font-size: 12px;
+}
+
+.font-format-bold {
+  font-size: 13.2px;
+  font-weight: bold;
+}
+
+.img-fit {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.item-quantity {
+  background-color: #f0ebe5;
+  border: 1px solid #e0dbd3;
+  border-radius: 5px;
+}
+
+.item-title {
+  color: #727272;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.item-list {
+  list-style:none;
+  padding-inline-start: 10px;
+  padding-top: 10px;
+  line-height: 2rem;
+  font-size: 0.9rem;
+}
+
+.panel {
+  background-color: #ffffff;
+  border-radius: 20px;
+  margin: 0 15px;
+}
+
+.panel-item {
+  background-color: #f8f8f8ff;
+  border-radius: 20px;
+  margin: 0px;
+  height: 182px;
+  width: 100%;
+}
+
+.panel-heading {
+  padding: 10px 15px;
+  font-size: 22px;
+  font-weight: bold;
+  border-bottom: 1px solid rgb(221, 221, 221);
+}
+
+.panel-item-heading {
+  padding: 10px 15px;
+  font-size: 15px;
+  font-weight: bold;
+  border-bottom: 1px solid rgb(221, 221, 221);
+}
+
+.panel-heading div {
+  margin: 0 18px;
+}
+
+.product-btn {
+  color: #454545;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.product-btn:hover {
+  color: #2a6496;
+}
+
+.product-img {
+  width: 95px;
+  height: 120px;
+  background-color: #eee;
+  display: block;
+}
+
+.product-name {
+  font-size: 16px;
+}
+
+.product-tag {
+  font-weight: bold;
+  border-radius: 5px;
+  padding: 3px 6px;
+}
+
+.side-heading {
+  padding: 10px 15px;
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.side-item-list {
+  list-style:none;
+  padding-inline-start: 10px;
+  padding-top: 10px;
+  line-height: 2rem;
+  font-size: 0.7rem;
+}
+
+.tag-gift {
+  background-color: #ffe14d;
+  color: #e53900;
+}
+
+.tag-preorder {
+  background-color: #34A853;
+  color: #ffffff;
+}

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -67,3 +67,6 @@
   color: #ffffff;
 }
 
+.text-pick {
+  color: #ff9600;
+}

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -70,3 +70,7 @@
 .text-pick {
   color: #ff9600;
 }
+
+.side-list-text {
+  font-size: 0.9rem;
+}

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,5 +1,6 @@
 const router = require('express').Router()
 const userCtrller = require('../controllers/userCtrller')
+const { isAuth } = require('../middleware/auth')
 
 // route base '/users'
 router.get('/', (req, res) => res.send('users page'))
@@ -8,6 +9,7 @@ router.post('/signup', userCtrller.signUp)
 router.get('/signin', userCtrller.getSignIn)
 router.post('/signin', userCtrller.signIn)
 router.get('/signout', userCtrller.signOut)
-router.get('/profile', userCtrller.getProfile)
+
+router.get('/profile', isAuth, userCtrller.getProfile)
 
 module.exports = router

--- a/routes/users.js
+++ b/routes/users.js
@@ -8,5 +8,6 @@ router.post('/signup', userCtrller.signUp)
 router.get('/signin', userCtrller.getSignIn)
 router.post('/signin', userCtrller.signIn)
 router.get('/signout', userCtrller.signOut)
+router.get('/profile', userCtrller.getProfile)
 
 module.exports = router

--- a/routes/users.js
+++ b/routes/users.js
@@ -11,5 +11,6 @@ router.post('/signin', userCtrller.signIn)
 router.get('/signout', userCtrller.signOut)
 
 router.get('/profile', isAuth, userCtrller.getProfile)
+router.get('/orders', isAuth, userCtrller.getOrders)
 
 module.exports = router

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -99,13 +99,13 @@
           </div>
           <hr class="my-2">
           <div>
-            <a href="/users/profile" class="font-weight-bold ml-2 text-decoration-none text-dark">帳戶設定</a>
+            <a href="/users/profile" class="font-weight-bold ml-2 text-decoration-none profile-href">我的帳戶</a>
             <ul class="side-item-list">
               <li>
-                <a href="#" class="text-decoration-none text-dark side-list-text">設定檔</a>
+                <a href="#" class="text-decoration-none profile-href side-list-text">設定檔</a>
               </li>
               <li>
-                <a href="#" class="text-decoration-none text-dark side-list-text">密碼變更</a>
+                <a href="#" class="text-decoration-none profile-href side-list-text">密碼變更</a>
               </li>
               <li>
                 <a href="/users/orders" class="text-decoration-none font-weight-bold text-pick side-list-text">訂購紀錄</a>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -69,31 +69,36 @@
             </div>
           </div>
         </div> --}}
-        <table class="table table-hover">
+        <table class="table table-sm mt-4 mb-0 mx-4">
           <thead>
             <tr>
-              <th scope="col">#</th>
-              <th scope="col">First</th>
-              <th scope="col">Last</th>
-              <th scope="col">Handle</th>
+              <th scope="col">訂單序號</th>
+              <th scope="col">成立日期</th>
+              <th scope="col">總金額</th>
+              <th scope="col">付款方式</th>
+              <th scope="col">付款狀態</th>
+              <th scope="col">寄送狀態</th>
+              <th scope="col">訂單內容</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <th scope="row" id="accordion">1</th>
+              <th id="accordion">1</th>
               <td>Mark</td>
               <td>Otto</td>
               <td>@mdo</td>
+              <td>@mdo</td>
+              <td>@mdo</td>
               <td>
                 <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne">
-                  Collapsible Group Item #1
+                  111
                 </button>
               </td>
             </tr>
           </tbody>
         </table>
         <div id="collapseOne" class="collapse" data-parent="#accordion">
-          <div class="card-body">
+          <div class="card-body pt-0">
             Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3
             wolf
             moon

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -1,0 +1,143 @@
+<main class="container pt-2 pb-5">
+  <div class="row">
+    {{!-- 主卡片 --}}
+    <section class="col-md-9 mb-5 p-3">
+      <div class="row panel mx-1">
+        <div class="panel-heading col-md-12">
+          <div class="mt-3">訂購紀錄</div>
+        </div>
+        {{!-- 內層卡片 --}}
+        {{!-- <div class="col-md-12 py-5">
+          <div class="row">
+            <div class="panel-item col-md-5  py-2 mb-4 ml-5">
+              <div class="panel-item-heading col-md-12">
+                <div>設定檔</div>
+              </div>
+              <div>
+                <ul class="item-list">
+                  <li><a href="#" class="text-decoration-none text-dark">更新設定檔</a></li>
+                  <li><a href="#" class="text-decoration-none text-dark">密碼變更</a></li>
+                </ul>
+              </div>
+            </div>
+            <div class="panel-item col-md-5  py-2 mb-4 ml-4">
+              <div class="panel-item-heading col-md-12">
+                <div>通訊錄</div>
+              </div>
+              <div>
+                <ul class="item-list">
+                  <li><a href="#" class="text-decoration-none text-dark">通訊地址管理</a></li>
+                </ul>
+              </div>
+            </div>
+            <div class="panel-item col-md-5  py-2 mb-4 ml-5">
+              <div class="panel-item-heading col-md-12">
+                <div>訂購紀錄</div>
+              </div>
+              <div>
+                <ul class="item-list">
+                  <li><a href="/users/orders" class="text-decoration-none text-dark">訂購紀錄</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div> --}}
+        {{!-- <div id="accordion" class="my-5 px-5">
+          <div class="card">
+            <div class="card-header">
+              <h5 class="mb-0">
+                <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true"
+                  aria-controls="collapseOne">
+                  Collapsible Group Item #1
+                </button>
+              </h5>
+            </div>
+            <div id="collapseOne" class="collapse" data-parent="#accordion">
+              <div class="card-body">
+                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
+                moon
+                officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch
+                3 wolf
+                moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et.
+                Nihil anim
+                keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan
+                excepteur
+                butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you
+                probably
+                haven't heard of them accusamus labore sustainable VHS.
+              </div>
+            </div>
+          </div>
+        </div> --}}
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">First</th>
+              <th scope="col">Last</th>
+              <th scope="col">Handle</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row" id="accordion">1</th>
+              <td>Mark</td>
+              <td>Otto</td>
+              <td>@mdo</td>
+              <td>
+                <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne">
+                  Collapsible Group Item #1
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div id="collapseOne" class="collapse" data-parent="#accordion">
+          <div class="card-body">
+            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3
+            wolf
+            moon
+            officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
+            Brunch
+            3 wolf
+            moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et.
+            Nihil anim
+            keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan
+            excepteur
+            butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt
+            you
+            probably
+            haven't heard of them accusamus labore sustainable VHS.
+          </div>
+        </div>
+      </div>
+    </section>
+    {{!-- 側邊欄 --}}
+    <section class="col-md-3 mb-5 p-3">
+      <div class="row panel mx-1 side-box-shadow">
+        <div class="panel-body w-100 p-3">
+          <div>
+            <div class="side-heading col-md-12">
+              <div><i class="fas fa-user mr-2"></i> 帳戶</div>
+            </div>
+          </div>
+          <hr class="my-2">
+          <div>
+            <p class="font-weight-bold ml-2">帳戶設定</p>
+            <ul class="side-item-list">
+              <li>
+                <a href="#" class="text-decoration-none text-dark">設定檔</a>
+              </li>
+              <li>
+                <a href="#" class="text-decoration-none text-dark">密碼變更</a>
+              </li>
+              <li>
+                <a href="/users/orders" class="text-decoration-none font-weight-bold text-pick">訂購紀錄</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -26,7 +26,7 @@
                       <tr>
                         <td class="accordion-thead">{{this.sn}}</td>
                         <td class="accordion-thead">{{this.createdTime}}</td>
-                        <td class="accordion-thead">{{this.amountFormat}}</td>
+                        <td class="accordion-thead">NTD {{this.amountFormat}}</td>
                       </tr>
                     </tbody>
                   </table>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -6,77 +6,104 @@
         <div class="panel-heading col-md-12">
           <div class="mt-3">訂購紀錄</div>
         </div>
+        <table class="table table-sm mt-4 mb-0 mx-4">
+          <thead>
+            <tr>
+              <th scope="col" class="accordion-thead">訂單序號</th>
+              <th scope="col" class="accordion-thead">成立日期</th>
+              <th scope="col" class="accordion-thead">總金額</th>
+            </tr>
+          </thead>
+        </table>
         {{#if orders}}
-          {{#each orders}}
-            <table class="table table-sm mt-4 mb-0 mx-4">
-              <thead>
-                <tr>
-                  <th scope="col">訂單序號</th>
-                  <th scope="col">成立日期</th>
-                  <th scope="col">總金額</th>
-                  <th scope="col">付款方式</th>
-                  <th scope="col">付款狀態</th>
-                  <th scope="col">寄送狀態</th>
-                  <th scope="col">訂單內容</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th id="accordion">{{this.sn}}</th>
-                  <td>{{this.createdTime}}</td>
-                  <td>{{this.amountFormat}}</td>
-                  <td>{{this.payMethod}}</td>
-                  <td>
-                    {{#if this.payStatus}}
-                      已付款
-                    {{else}}
-                      未付款
-                    {{/if}}
-                  </td>
-                  <td>
-                    {{#if this.shipStatus}}
-                      已出貨
-                    {{else}}
-                      未出貨
-                    {{/if}}
-                  </td>
-                  <td>
-                    <button class="btn text-pick pt-0" data-toggle="collapse" data-target="#collapse_{{this.id}}">
-                      <i class="fas fa-search"></i>
-                    </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <div id="collapse_{{this.id}}" class="collapse col-12" data-parent="#accordion">
-              <div class="card-body row pt-0 pl-5">
-                <div class="col-4">
-                  <h6 class="border-bottom">收件資訊</h6>
-                  <p>{{this.receiver}}</p>
-                  <p>{{this.phone}}</p>
-                  <p>{{this.address}}</p>
+          <div id="accordion" class="mb-4">
+            {{#each orders}}
+              <div class="card mx-4 mt-2">
+                <div class="card-header order-card" class="btn btn-link btn-block" data-toggle="collapse"
+                  data-target="#collapseOne_{{this.id}}">
+                  <table>
+                    <tbody>
+                      <tr>
+                        <td class="accordion-thead">{{this.sn}}</td>
+                        <td class="accordion-thead">{{this.createdTime}}</td>
+                        <td class="accordion-thead">{{this.amountFormat}}</td>
+                      </tr>
+                    </tbody>
+                  </table>
                 </div>
-                <div class="col-8">
-                  <h6 class="border-bottom">出貨清單</h6>
-                  {{#each this.products}}
-                    <div class="row col-12 mb-2">
-                      <a href="/products/{{this.id}}" class="product-img">
-                        <img src="{{this.mainImg}}" class="rounded mx-auto d-block" alt="productImage"
-                          style="height:50px">
-                      </a>
-                      <div>
-                        <div class="ml-3">{{this.name}}</div>
-                        <div class="row ml-3">
-                          <div>NTD {{this.orderPrice}}</div>
-                          <div class="ml-3">x {{this.OrderItem.quantity}}</div>
-                        </div>
-                      </div>
-                    </div>
-                  {{/each}}
+                <div id="collapseOne_{{this.id}}" class="collapse" aria-labelledby="headingOne"
+                  data-parent="#accordion">
+                  <div class="card-body">
+                    <table class="order-info">
+                      <tbody>
+                        <tr>
+                          <td class="accordion-title">收件人</td>
+                          <td class="accordion-data">{{this.receiver}}</td>
+                        </tr>
+                        <tr>
+                          <td class="accordion-title">聯絡電話</td>
+                          <td class="accordion-data">{{this.phone}}</td>
+                        </tr>
+                        <tr>
+                          <td class="accordion-title">收件地址</td>
+                          <td class="accordion-data">{{this.address}}</td>
+                        </tr>
+                        <tr>
+                          <td class="accordion-title">付款方式</td>
+                          <td class="accordion-data">{{this.payMethod}}</td>
+                        </tr>
+                        <tr>
+                          <td class="accordion-title">付款狀態</td>
+                          <td class="accordion-data">
+                            {{#if this.payStatus}}
+                              已付款
+                            {{else}}
+                              未付款
+                            {{/if}}
+                          </td>
+                        </tr>
+                        <tr>
+                          <td class="accordion-title">出貨狀態</td>
+                          <td class="accordion-data">
+                            {{#if this.shipStatus}}
+                              已出貨
+                            {{else}}
+                              未出貨
+                            {{/if}}
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <hr>
+                    <table class="order-info">
+                      <tbody>
+                        {{#each this.products}}
+                          <tr>
+                            <td class="accordion-title"></td>
+                            <td class="accordion-data">
+                              <div class="row col-12 mb-2">
+                                <a href="/products/{{this.id}}" class="product-img">
+                                  <img src="{{this.mainImg}}" class="rounded mx-auto d-block" alt="productImage"
+                                    style="height:50px">
+                                </a>
+                                <div>
+                                  <div class="ml-3">{{this.name}}</div>
+                                  <div class="row ml-3">
+                                    <div>NTD {{this.orderPrice}}</div>
+                                    <div class="ml-3">x {{this.OrderItem.quantity}}</div>
+                                  </div>
+                                </div>
+                              </div>
+                            </td>
+                          </tr>
+                        {{/each}}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               </div>
-            </div>
-          {{/each}}
+            {{/each}}
+          </div>
         {{else}}
           <div class="col-12 my-3">
             <div class="text-center">
@@ -87,6 +114,7 @@
           </div>
         {{/if}}
       </div>
+      <br>
     </section>
     {{!-- 側邊欄 --}}
     <section class="col-md-3 mb-5 p-3">

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -99,7 +99,7 @@
           </div>
           <hr class="my-2">
           <div>
-            <p class="font-weight-bold ml-2">帳戶設定</p>
+            <a href="/users/profile" class="font-weight-bold ml-2 text-decoration-none text-dark">帳戶設定</a>
             <ul class="side-item-list">
               <li>
                 <a href="#" class="text-decoration-none text-dark">設定檔</a>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -102,13 +102,13 @@
             <a href="/users/profile" class="font-weight-bold ml-2 text-decoration-none text-dark">帳戶設定</a>
             <ul class="side-item-list">
               <li>
-                <a href="#" class="text-decoration-none text-dark">設定檔</a>
+                <a href="#" class="text-decoration-none text-dark side-list-text">設定檔</a>
               </li>
               <li>
-                <a href="#" class="text-decoration-none text-dark">密碼變更</a>
+                <a href="#" class="text-decoration-none text-dark side-list-text">密碼變更</a>
               </li>
               <li>
-                <a href="/users/orders" class="text-decoration-none font-weight-bold text-pick">訂購紀錄</a>
+                <a href="/users/orders" class="text-decoration-none font-weight-bold text-pick side-list-text">訂購紀錄</a>
               </li>
             </ul>
           </div>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -6,76 +6,86 @@
         <div class="panel-heading col-md-12">
           <div class="mt-3">訂購紀錄</div>
         </div>
-        {{#each orders}}
-          <table class="table table-sm mt-4 mb-0 mx-4">
-            <thead>
-              <tr>
-                <th scope="col">訂單序號</th>
-                <th scope="col">成立日期</th>
-                <th scope="col">總金額</th>
-                <th scope="col">付款方式</th>
-                <th scope="col">付款狀態</th>
-                <th scope="col">寄送狀態</th>
-                <th scope="col">訂單內容</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th id="accordion">{{this.sn}}</th>
-                <td>{{this.createdTime}}</td>
-                <td>{{this.amountFormat}}</td>
-                <td>{{this.payMethod}}</td>
-                <td>
-                  {{#if this.payStatus}}
-                    已付款
-                  {{else}}
-                    未付款
-                  {{/if}}
-                </td>
-                <td>
-                  {{#if this.shipStatus}}
-                    已出貨
-                  {{else}}
-                    未出貨
-                  {{/if}}
-                </td>
-                <td>
-                  <button class="btn text-pick pt-0" data-toggle="collapse" data-target="#collapse_{{this.id}}">
-                    <i class="fas fa-search"></i>
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <div id="collapse_{{this.id}}" class="collapse col-12" data-parent="#accordion">
-            <div class="card-body row pt-0 pl-5">
-              <div class="col-4">
-                <h6 class="border-bottom">收件資訊</h6>
-                <p>{{this.receiver}}</p>
-                <p>{{this.phone}}</p>
-                <p>{{this.address}}</p>
-              </div>
-              <div class="col-8">
-                <h6 class="border-bottom">出貨清單</h6>
-                {{#each this.products}}
-                  <div class="row col-12 mb-2">
-                    <a href="/products/{{this.id}}" class="product-img">
-                      <img src="{{this.mainImg}}" class="rounded mx-auto d-block" alt="productImage"
-                        style="height:50px">
-                    </a>
-                    <div>
-                      <div class="ml-3">{{this.name}}</div>
-                      <div class="row ml-3">
-                        <div>NTD {{this.orderPrice}}</div>
-                        <div class="ml-3">x {{this.OrderItem.quantity}}</div>
+        {{#if orders}}
+          {{#each orders}}
+            <table class="table table-sm mt-4 mb-0 mx-4">
+              <thead>
+                <tr>
+                  <th scope="col">訂單序號</th>
+                  <th scope="col">成立日期</th>
+                  <th scope="col">總金額</th>
+                  <th scope="col">付款方式</th>
+                  <th scope="col">付款狀態</th>
+                  <th scope="col">寄送狀態</th>
+                  <th scope="col">訂單內容</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th id="accordion">{{this.sn}}</th>
+                  <td>{{this.createdTime}}</td>
+                  <td>{{this.amountFormat}}</td>
+                  <td>{{this.payMethod}}</td>
+                  <td>
+                    {{#if this.payStatus}}
+                      已付款
+                    {{else}}
+                      未付款
+                    {{/if}}
+                  </td>
+                  <td>
+                    {{#if this.shipStatus}}
+                      已出貨
+                    {{else}}
+                      未出貨
+                    {{/if}}
+                  </td>
+                  <td>
+                    <button class="btn text-pick pt-0" data-toggle="collapse" data-target="#collapse_{{this.id}}">
+                      <i class="fas fa-search"></i>
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div id="collapse_{{this.id}}" class="collapse col-12" data-parent="#accordion">
+              <div class="card-body row pt-0 pl-5">
+                <div class="col-4">
+                  <h6 class="border-bottom">收件資訊</h6>
+                  <p>{{this.receiver}}</p>
+                  <p>{{this.phone}}</p>
+                  <p>{{this.address}}</p>
+                </div>
+                <div class="col-8">
+                  <h6 class="border-bottom">出貨清單</h6>
+                  {{#each this.products}}
+                    <div class="row col-12 mb-2">
+                      <a href="/products/{{this.id}}" class="product-img">
+                        <img src="{{this.mainImg}}" class="rounded mx-auto d-block" alt="productImage"
+                          style="height:50px">
+                      </a>
+                      <div>
+                        <div class="ml-3">{{this.name}}</div>
+                        <div class="row ml-3">
+                          <div>NTD {{this.orderPrice}}</div>
+                          <div class="ml-3">x {{this.OrderItem.quantity}}</div>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                {{/each}}
+                  {{/each}}
+                </div>
               </div>
             </div>
+          {{/each}}
+        {{else}}
+          <div class="col-12 my-3">
+            <div class="text-center">
+              <p class="mb-3">你還沒有訂購記錄喔!</p>
+              <p>- Tip -</p>
+              <p>完成結帳以增加訂購紀錄</p>
+            </div>
           </div>
-        {{/each}}
+        {{/if}}
       </div>
     </section>
     {{!-- 側邊欄 --}}

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -6,115 +6,76 @@
         <div class="panel-heading col-md-12">
           <div class="mt-3">訂購紀錄</div>
         </div>
-        {{!-- 內層卡片 --}}
-        {{!-- <div class="col-md-12 py-5">
-          <div class="row">
-            <div class="panel-item col-md-5  py-2 mb-4 ml-5">
-              <div class="panel-item-heading col-md-12">
-                <div>設定檔</div>
+        {{#each orders}}
+          <table class="table table-sm mt-4 mb-0 mx-4">
+            <thead>
+              <tr>
+                <th scope="col">訂單序號</th>
+                <th scope="col">成立日期</th>
+                <th scope="col">總金額</th>
+                <th scope="col">付款方式</th>
+                <th scope="col">付款狀態</th>
+                <th scope="col">寄送狀態</th>
+                <th scope="col">訂單內容</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th id="accordion">{{this.sn}}</th>
+                <td>{{this.createdTime}}</td>
+                <td>{{this.amountFormat}}</td>
+                <td>{{this.payMethod}}</td>
+                <td>
+                  {{#if this.payStatus}}
+                    已付款
+                  {{else}}
+                    未付款
+                  {{/if}}
+                </td>
+                <td>
+                  {{#if this.shipStatus}}
+                    已出貨
+                  {{else}}
+                    未出貨
+                  {{/if}}
+                </td>
+                <td>
+                  <button class="btn text-pick pt-0" data-toggle="collapse" data-target="#collapse_{{this.id}}">
+                    <i class="fas fa-search"></i>
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div id="collapse_{{this.id}}" class="collapse col-12" data-parent="#accordion">
+            <div class="card-body row pt-0 pl-5">
+              <div class="col-4">
+                <h6 class="border-bottom">收件資訊</h6>
+                <p>{{this.receiver}}</p>
+                <p>{{this.phone}}</p>
+                <p>{{this.address}}</p>
               </div>
-              <div>
-                <ul class="item-list">
-                  <li><a href="#" class="text-decoration-none text-dark">更新設定檔</a></li>
-                  <li><a href="#" class="text-decoration-none text-dark">密碼變更</a></li>
-                </ul>
-              </div>
-            </div>
-            <div class="panel-item col-md-5  py-2 mb-4 ml-4">
-              <div class="panel-item-heading col-md-12">
-                <div>通訊錄</div>
-              </div>
-              <div>
-                <ul class="item-list">
-                  <li><a href="#" class="text-decoration-none text-dark">通訊地址管理</a></li>
-                </ul>
-              </div>
-            </div>
-            <div class="panel-item col-md-5  py-2 mb-4 ml-5">
-              <div class="panel-item-heading col-md-12">
-                <div>訂購紀錄</div>
-              </div>
-              <div>
-                <ul class="item-list">
-                  <li><a href="/users/orders" class="text-decoration-none text-dark">訂購紀錄</a></li>
-                </ul>
+              <div class="col-8">
+                <h6 class="border-bottom">出貨清單</h6>
+                {{#each this.products}}
+                  <div class="row col-12 mb-2">
+                    <a href="/products/{{this.id}}" class="product-img">
+                      <img src="{{this.mainImg}}" class="rounded mx-auto d-block" alt="productImage"
+                        style="height:50px">
+                    </a>
+                    <div>
+                      <div class="ml-3">{{this.name}}</div>
+                      <div class="row ml-3">
+                        <div>NTD {{this.orderPrice}}</div>
+                        <div class="ml-3">x {{this.OrderItem.quantity}}</div>
+                      </div>
+                    </div>
+                  </div>
+                {{/each}}
               </div>
             </div>
           </div>
-        </div> --}}
-        {{!-- <div id="accordion" class="my-5 px-5">
-          <div class="card">
-            <div class="card-header">
-              <h5 class="mb-0">
-                <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true"
-                  aria-controls="collapseOne">
-                  Collapsible Group Item #1
-                </button>
-              </h5>
-            </div>
-            <div id="collapseOne" class="collapse" data-parent="#accordion">
-              <div class="card-body">
-                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
-                moon
-                officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch
-                3 wolf
-                moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et.
-                Nihil anim
-                keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan
-                excepteur
-                butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you
-                probably
-                haven't heard of them accusamus labore sustainable VHS.
-              </div>
-            </div>
-          </div>
-        </div> --}}
-        <table class="table table-sm mt-4 mb-0 mx-4">
-          <thead>
-            <tr>
-              <th scope="col">訂單序號</th>
-              <th scope="col">成立日期</th>
-              <th scope="col">總金額</th>
-              <th scope="col">付款方式</th>
-              <th scope="col">付款狀態</th>
-              <th scope="col">寄送狀態</th>
-              <th scope="col">訂單內容</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th id="accordion">1</th>
-              <td>Mark</td>
-              <td>Otto</td>
-              <td>@mdo</td>
-              <td>@mdo</td>
-              <td>@mdo</td>
-              <td>
-                <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne">
-                  111
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div id="collapseOne" class="collapse" data-parent="#accordion">
-          <div class="card-body pt-0">
-            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3
-            wolf
-            moon
-            officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
-            Brunch
-            3 wolf
-            moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et.
-            Nihil anim
-            keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan
-            excepteur
-            butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt
-            you
-            probably
-            haven't heard of them accusamus labore sustainable VHS.
-          </div>
-        </div>
+        {{/each}}
       </div>
     </section>
     {{!-- 側邊欄 --}}

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -3,12 +3,19 @@
     <div class="container py-3">
       <a href="/" class="navbar-brand">LOGO</a>
       <div>
-        <a class="btn btn-primary mr-2 btn-top-bar" href="/users/signin">登入·註冊</a>
+        {{#if isAuthenticated}}
+          <a href="/users/profile" class="btn btn-primary mr-2 btn-top-bar" style="line-height: 1.5rem;">
+            <span class="userpage-item">歡迎 {{user.nickname}}</span>
+            </br>
+            <span class="userpage-item userpage-link">我的帳戶</span>
+          </a>
+        {{else}}
+          <a class="btn btn-primary mr-2 btn-top-bar" href="/users/signin">登入·註冊</a>
+        {{/if}}
         <a class="btn btn-primary btn-top-bar" href="/cart">購物車 {{itemSum}}</a>
       </div>
     </div>
   </div>
-
   <div class="container-fluid category-bar">
     <ul class="nav mx-auto">
       <li class="nav-item px-3">
@@ -28,7 +35,6 @@
       </li>
     </ul>
   </div>
-
   <div class="container-fluid py-2 search-bar">
     <div class="row mx-auto">
       <div class="col-md-12 ">

--- a/views/profile.hbs
+++ b/views/profile.hbs
@@ -15,8 +15,8 @@
               </div>
               <div>
                 <ul class="item-list">
-                  <li><a href="#" class="text-decoration-none text-dark">更新設定檔</a></li>
-                  <li><a href="#" class="text-decoration-none text-dark">密碼變更</a></li>
+                  <li><a href="#" class="text-decoration-none profile-href">更新設定檔</a></li>
+                  <li><a href="#" class="text-decoration-none profile-href ">密碼變更</a></li>
                 </ul>
               </div>
             </div>
@@ -26,7 +26,7 @@
               </div>
               <div>
                 <ul class="item-list">
-                  <li><a href="#" class="text-decoration-none text-dark">通訊地址管理</a></li>
+                  <li><a href="#" class="text-decoration-none profile-href ">通訊地址管理</a></li>
                 </ul>
               </div>
             </div>
@@ -36,7 +36,7 @@
               </div>
               <div>
                 <ul class="item-list">
-                  <li><a href="/users/orders" class="text-decoration-none text-dark">訂購紀錄</a></li>
+                  <li><a href="/users/orders" class="text-decoration-none profile-href ">訂購紀錄</a></li>
                 </ul>
               </div>
             </div>
@@ -55,16 +55,16 @@
           </div>
           <hr class="my-2">
           <div>
-            <a href="/users/profile" class="font-weight-bold ml-2 text-decoration-none text-dark">帳戶設定</a>
+            <a href="/users/profile" class="font-weight-bold ml-2 text-decoration-none profile-href">我的帳戶</a>
             <ul class="side-item-list">
               <li>
-                <a href="#" class="text-decoration-none text-dark side-list-text">設定檔</a>
+                <a href="#" class="text-decoration-none profile-href side-list-text">設定檔</a>
               </li>
               <li>
-                <a href="#" class="text-decoration-none text-dark side-list-text">密碼變更</a>
+                <a href="#" class="text-decoration-none profile-href side-list-text">密碼變更</a>
               </li>
               <li>
-                <a href="/users/orders" class="text-decoration-none text-dark side-list-text">訂購紀錄</a>
+                <a href="/users/orders" class="text-decoration-none profile-href side-list-text">訂購紀錄</a>
               </li>
             </ul>
           </div>

--- a/views/profile.hbs
+++ b/views/profile.hbs
@@ -55,7 +55,7 @@
           </div>
           <hr class="my-2">
           <div>
-            <p class="font-weight-bold ml-2">帳戶設定</p>
+            <a href="/users/profile" class="font-weight-bold ml-2 text-decoration-none text-dark">帳戶設定</a>
             <ul class="side-item-list">
               <li>
                 <a href="#" class="text-decoration-none text-dark">設定檔</a>

--- a/views/profile.hbs
+++ b/views/profile.hbs
@@ -58,13 +58,13 @@
             <a href="/users/profile" class="font-weight-bold ml-2 text-decoration-none text-dark">帳戶設定</a>
             <ul class="side-item-list">
               <li>
-                <a href="#" class="text-decoration-none text-dark">設定檔</a>
+                <a href="#" class="text-decoration-none text-dark side-list-text">設定檔</a>
               </li>
               <li>
-                <a href="#" class="text-decoration-none text-dark">密碼變更</a>
+                <a href="#" class="text-decoration-none text-dark side-list-text">密碼變更</a>
               </li>
               <li>
-                <a href="/users/orders" class="text-decoration-none text-dark">訂購紀錄</a>
+                <a href="/users/orders" class="text-decoration-none text-dark side-list-text">訂購紀錄</a>
               </li>
             </ul>
           </div>

--- a/views/profile.hbs
+++ b/views/profile.hbs
@@ -1,0 +1,75 @@
+<main class="container pt-2 pb-5">
+  <div class="row">
+    {{!-- 主卡片 --}}
+    <section class="col-md-9 mb-5 p-3">
+      <div class="row panel mx-1">
+        <div class="panel-heading col-md-12">
+          <div class="mt-3">我的帳戶</div>
+        </div>
+        {{!-- 內層卡片 --}}
+        <div class="col-md-12 py-5">
+          <div class="row">
+            <div class="panel-item col-md-5  py-2 mb-4 ml-5">
+              <div class="panel-item-heading col-md-12">
+                <div>設定檔</div>
+              </div>
+              <div>
+                <ul class="item-list">
+                  <li><a href="#" class="text-decoration-none text-dark">更新設定檔</a></li>
+                  <li><a href="#" class="text-decoration-none text-dark">密碼變更</a></li>
+                </ul>
+              </div>
+            </div>
+            <div class="panel-item col-md-5  py-2 mb-4 ml-4">
+              <div class="panel-item-heading col-md-12">
+                <div>通訊錄</div>
+              </div>
+              <div>
+                <ul class="item-list">
+                  <li><a href="#" class="text-decoration-none text-dark">通訊地址管理</a></li>
+                </ul>
+              </div>
+            </div>
+            <div class="panel-item col-md-5  py-2 mb-4 ml-5">
+              <div class="panel-item-heading col-md-12">
+                <div>訂購紀錄</div>
+              </div>
+              <div>
+                <ul class="item-list">
+                  <li><a href="/users/orders" class="text-decoration-none text-dark">訂購紀錄</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    {{!-- 側邊欄 --}}
+    <section class="col-md-3 mb-5 p-3">
+      <div class="row panel mx-1 font-format">
+        <div class="panel-body w-100 p-3">
+          <div>
+            <div class="side-heading col-md-12">
+              <div><i class="fas fa-user mr-2"></i> 帳戶</div>
+            </div>
+          </div>
+          <hr class="my-2">
+          <div>
+            <p class="font-weight-bold ml-2">帳戶設定</p>
+            <ul class="side-item-list">
+              <li>
+                <a href="#" class="text-decoration-none text-dark">設定檔</a>
+              </li>
+              <li>
+                <a href="#" class="text-decoration-none text-dark">密碼變更</a>
+              </li>
+              <li>
+                <a href="/users/orders" class="text-decoration-none text-dark">訂購紀錄</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>

--- a/views/profile.hbs
+++ b/views/profile.hbs
@@ -46,7 +46,7 @@
     </section>
     {{!-- 側邊欄 --}}
     <section class="col-md-3 mb-5 p-3">
-      <div class="row panel mx-1 font-format">
+      <div class="row panel mx-1 side-box-shadow">
         <div class="panel-body w-100 p-3">
           <div>
             <div class="side-heading col-md-12">


### PR DESCRIPTION
## 完成頁面
- navbar動線
- 使用者帳戶頁
- 使用者訂單頁

## 手動確認

- 未登入狀態下，直接連至`/users/profile`或`/users/orders`會被導回登入頁面
- 使用者(非root)登入後，navber會顯示進入使用者帳戶頁之動線
<img width="366" alt="螢幕快照 2020-01-03 上午1 09 50" src="https://user-images.githubusercontent.com/49901777/71680698-c54a2780-2dc5-11ea-9d3d-8c49c00f99c3.png">

- 點擊該按鈕可進入到使用者頁面
<img width="1440" alt="螢幕快照 2020-01-03 上午1 11 02" src="https://user-images.githubusercontent.com/49901777/71680775-ef9be500-2dc5-11ea-97bb-4b95e61bd163.png">

- 點選主卡片或側邊欄的"訂購紀錄"皆可連結至使用者訂單頁面
<img width="1440" alt="螢幕快照 2020-01-03 上午1 15 21" src="https://user-images.githubusercontent.com/49901777/71681002-8f597300-2dc6-11ea-9456-2ff169ba05de.png">

- 訂單頁面僅會顯示登入使用者的訂單資訊且資訊正確
- 每筆訂單可以按下後方的訂單內容按鈕來展開/收納收件資訊與出貨資訊
<img width="1440" alt="螢幕快照 2020-01-03 上午1 16 43" src="https://user-images.githubusercontent.com/49901777/71681080-bc0d8a80-2dc6-11ea-8488-1eb44aa96387.png">

- 使用者無訂購紀錄時會顯示提示訊息
<img width="1440" alt="螢幕快照 2020-01-03 上午1 23 23" src="https://user-images.githubusercontent.com/49901777/71681492-d136e900-2dc7-11ea-991a-4e14725220e4.png">

## 其他
- 歡迎各種版面與色彩建議QQ


