### PR TITLE
【加入】checkout 結帳頁4、最後檢視

### DIFF
--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -26,6 +26,7 @@ module.exports = {
       // 製作頁面資料
       const products = cart.products
       let totalPrice = 0
+      const shippingFee = 150
       products.forEach(prod => {
         prod.quantity = prod.CartItem.quantity
         prod.amount = (prod.price * prod.quantity)
@@ -33,9 +34,9 @@ module.exports = {
       })
 
       // 預設運費
-      const totalPrice2 = totalPrice + 150
+      const totalPrice2 = totalPrice + shippingFee
       
-      res.render('view', { css: 'view', cart, totalPrice, totalPrice2 })
+      res.render('view', { css: 'view', cart, totalPrice, totalPrice2, shippingFee })
 
     } catch (err) {
       console.error(err)

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -4,8 +4,38 @@ const Cart = db.Cart
 module.exports = {
   async viewPage(req, res) {
     try {
+      const cartId = req.session.cartId
+      const cart = await Cart.findByPk(cartId, {
+        include: [
+          {
+            association: 'products',
+            attributes: ['id', 'name', 'price'],
+            include: [{
+              association: 'Images',
+              where: { is_main: true }
+            }],
+          }
+        ]
+      })
+
+      // 確認有無選購商品
+      if (!cart || !cart.products.length) {
+        return res.redirect('/cart')
+      }
+
+      // 製作頁面資料
+      const products = cart.products
+      let totalPrice = 0
+      products.forEach(prod => {
+        prod.quantity = prod.CartItem.quantity
+        prod.amount = (prod.price * prod.quantity)
+        totalPrice += prod.amount
+      })
+
+      // 預設運費
+      const totalPrice2 = totalPrice + 150
       
-      res.render('view', { css: 'view' })
+      res.render('view', { css: 'view', cart, totalPrice, totalPrice2 })
 
     } catch (err) {
       console.error(err)

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -1,0 +1,15 @@
+const db = require('../models')
+const Cart = db.Cart
+
+module.exports = {
+  async viewPage(req, res) {
+    try {
+      
+      res.render('view', { css: 'view' })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  }
+}

--- a/lib/hbs_helpers.js
+++ b/lib/hbs_helpers.js
@@ -2,4 +2,8 @@ module.exports = {
   ifEqual: function (arg1, arg2, options) {
     return (arg1 === arg2) ? options.fn(this) : options.inverse(this)
   },
+
+  addDot: function (arg1) {
+    return arg1 && arg1.toLocaleString()
+  }
 }

--- a/public/css/view.css
+++ b/public/css/view.css
@@ -1,0 +1,96 @@
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+}
+
+.panel {
+  border-radius: 20px;
+  background: #fff;
+}
+
+/* nav step */
+.step {
+  font-size: .9rem;
+}
+
+.step li {
+  border-top: 3px solid #eee;
+  color: #d6d6d6;
+  font-weight: bolder;
+}
+
+.step li.active {
+  border-top: 3px solid #ff9400;
+  color: #000;
+  font-weight: normal;
+}
+
+/* form */
+.btn-edit {
+  color: #454545;
+  font-size: .85rem;
+  font-weight: bold;
+  line-height: 1.5rem;
+  border-radius: 5px;
+  background-color: #eeeeee;
+  width: 100px;
+  height: 40px;
+}
+
+.summary-content li {
+  color: #454545;
+  font-size: .85rem;
+  line-height: 1.5rem;
+  list-style-type: none;
+  text-align: left;
+}
+
+.order-btn {
+  display: inline-block;
+  background: #ff5400;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 10px;
+  padding: 1rem 1.5rem;
+  font-size: 1rem;
+}
+
+/* aside */
+aside .panel {
+  box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, .25);
+}
+
+.font-small {
+  font-size: .85rem;
+}
+
+.font-smaller {
+  font-size: .7rem;
+}
+
+.prod-list .row {
+  margin: 0;
+  padding: 1rem 0;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.prod-list .row:nth-last-child(1) {
+  border-bottom: 0;
+}
+
+.prod-list img {
+  width: 52px;
+  height: 52px;
+  padding: 2px;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: .25rem;
+}
+
+.prod-list a {
+  color: #000;
+}
+
+.prod-list a:hover {
+  color: #2a6496;;
+  text-decoration: none;
+}

--- a/public/css/view.css
+++ b/public/css/view.css
@@ -56,6 +56,17 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 1rem;
 }
 
+.order-btn-lg {          /* view */
+  display: inline-block;
+  background: #ff5400;
+  color: #fff;
+  font-size: 20px;
+  font-weight: bold;
+  border-radius: 10px;
+  padding: 1rem 1.5rem;
+  height: 100px;
+}
+
 .btn-edit {              /* view */
   color: #454545;
   font-size: .85rem;

--- a/public/css/view.css
+++ b/public/css/view.css
@@ -25,23 +25,25 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* form */
-.btn-edit {
-  color: #454545;
+.font-small {
   font-size: .85rem;
-  font-weight: bold;
-  line-height: 1.5rem;
-  border-radius: 5px;
-  background-color: #eeeeee;
-  width: 100px;
-  height: 40px;
 }
 
-.summary-content li {
-  color: #454545;
-  font-size: .85rem;
-  line-height: 1.5rem;
-  list-style-type: none;
-  text-align: left;
+.font-smaller {
+  font-size: .7rem;
+}
+
+.form-row [class*='col'] {
+  margin: 0 0 .75rem 0;
+}
+
+.form-row input {
+  display: block;
+  background: #f8f5f1;
+  border: 1px solid #e0dbd3;
+  padding: .3rem;
+  border-radius: 5px;
+  width: 100%;
 }
 
 .order-btn {
@@ -54,17 +56,28 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 1rem;
 }
 
+.btn-edit {              /* view */
+  color: #454545;
+  font-size: .85rem;
+  font-weight: bold;
+  line-height: 1.5rem;
+  border-radius: 5px;
+  background-color: #eeeeee;
+  width: 100px;
+  height: 40px;
+}
+
+.summary-content li {    /* view */
+  color: #454545;
+  font-size: .85rem;
+  line-height: 1.5rem;
+  list-style-type: none;
+  text-align: left;
+}
+
 /* aside */
 aside .panel {
   box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, .25);
-}
-
-.font-small {
-  font-size: .85rem;
-}
-
-.font-smaller {
-  font-size: .7rem;
 }
 
 .prod-list .row {

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,6 +10,7 @@ module.exports = app => {
   app.use('/', getCartItem)  // 請勿更動順序
   app.use('/products', require('./products.js'))
   app.use('/cart', require('./cart.js'))
+  app.use('/order', require('./order.js'))
   app.use('/users', require('./users.js'))
   app.use('/admin', require('./admin/index.js'))
 

--- a/routes/order.js
+++ b/routes/order.js
@@ -1,0 +1,8 @@
+const router = require('express').Router()
+const orderCtrller = require('../controllers/orderCtrller.js')
+
+// route base '/order'
+
+router.get('/view', orderCtrller.viewPage)
+
+module.exports = router

--- a/views/view.hbs
+++ b/views/view.hbs
@@ -36,7 +36,7 @@
         {{!-- 送貨選項 --}}
         <div class="row p-4 border-bottom">
           <section class="col-4">
-            <h6 class="mb-4 font-weight-bold">付款詳細資料</h6>
+            <h6 class="mb-4 font-weight-bold">送貨選項</h6>
             <a href="/order/delivery-method" class="btn btn-edit">編輯</a>
           </section>
           <section class="col-8 summary-content">

--- a/views/view.hbs
+++ b/views/view.hbs
@@ -43,7 +43,7 @@
             <div class="col-10">
               <ul class="pl-0">
                 <li>宅配 -</li>
-                <li>- NTD 150</li>
+                <li>- NTD {{shippingFee}}</li>
               </ul>
             </div>
           </section>
@@ -94,7 +94,7 @@
           </div>
           <div class="d-flex justify-content-between border-bottom py-2 font-small">
             <span>運費:</span>
-            <span>NTD 150</span>
+            <span>NTD {{shippingFee}}</span>
           </div>
           <div class="d-flex justify-content-between font-weight-bold py-2">
             <span>合計:</span>

--- a/views/view.hbs
+++ b/views/view.hbs
@@ -83,7 +83,15 @@
 
     {{!-- 側邊攔 --}}
     <aside class="col-4">
-      
+      <section class="panel mb-4">
+        <div class="p-3">
+          <form action="#" method="POST">
+            <button class="btn order-btn-lg w-100">
+              <i class="fas fa-check"></i>  確定結帳
+            </button>
+          </form>
+        </div>
+      </section>
       {{!-- 總金額 --}}
       <section class="panel mb-4">
         <h6 class="font-weight-bold border-bottom p-3">訂單合計</h6>

--- a/views/view.hbs
+++ b/views/view.hbs
@@ -111,14 +111,15 @@
                 <img src="{{Images.0.url}}" alt="product-img">
               </a>
             </div>
-            <div class="col-10 pl-2">
+            <div class="col-10 pl-2 pr-0">
               <a href="/products/{{id}}">
                 <h6 class="mb-3">{{name}}</h6>
               </a>
               <div class="font-smaller">
-                <div class="w-50 ml-auto text-left">
-                  <p>NTD 1,000 x 1 =</p>
-                  <p class="font-weight-bold">NTD 1,000</p>
+                <div class="w-75 ml-auto text-right">
+                  <p>NTD 1,000 x 1 =
+                    <span class="font-weight-bold">NTD 1,000</span>
+                  </p>
                 </div>
               </div>
             </div>

--- a/views/view.hbs
+++ b/views/view.hbs
@@ -83,13 +83,14 @@
 
     {{!-- 側邊攔 --}}
     <aside class="col-4">
+      
       {{!-- 總金額 --}}
       <section class="panel mb-4">
         <h6 class="font-weight-bold border-bottom p-3">訂單合計</h6>
         <div class="px-3 pb-3">
           <div class="d-flex justify-content-between border-bottom py-2 font-small">
             <span>小計:</span>
-            <span>NTD 1,000</span>
+            <span>NTD {{addDot totalPrice}}</span>
           </div>
           <div class="d-flex justify-content-between border-bottom py-2 font-small">
             <span>運費:</span>
@@ -97,7 +98,7 @@
           </div>
           <div class="d-flex justify-content-between font-weight-bold py-2">
             <span>合計:</span>
-            <span>NTD 1,150</span>
+            <span>NTD {{addDot totalPrice2}}</span>
           </div>
         </div>
       </section>
@@ -105,25 +106,27 @@
       <section class="panel">
         <h6 class="font-weight-bold border-bottom p-3">配送商品</h6>
         <div class="prod-list px-3">
-          <div class="row">
-            <div class="col-2 px-0">
-              <a href="/products/{{id}}">
-                <img src="{{Images.0.url}}" alt="product-img">
-              </a>
-            </div>
-            <div class="col-10 pl-2 pr-0">
-              <a href="/products/{{id}}">
-                <h6 class="mb-3">{{name}}</h6>
-              </a>
-              <div class="font-smaller">
-                <div class="w-75 ml-auto text-right">
-                  <p>NTD 1,000 x 1 =
-                    <span class="font-weight-bold">NTD 1,000</span>
-                  </p>
+          {{#each cart.products}}
+            <div class="row">
+              <div class="col-2 px-0">
+                <a href="/products/{{id}}">
+                  <img src="{{Images.0.url}}" alt="product-img">
+                </a>
+              </div>
+              <div class="col-10 pl-2 pr-0">
+                <a href="/products/{{id}}">
+                  <h6 class="mb-3">{{name}}</h6>
+                </a>
+                <div class="font-smaller">
+                  <div class="w-75 ml-auto text-right">
+                    <p>NTD {{addDot price}} x {{addDot quantity}} =
+                      <span class="font-weight-bold">NTD {{addDot amount}}</span>
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          {{/each}}
         </div>
       </section>
     </aside>

--- a/views/view.hbs
+++ b/views/view.hbs
@@ -37,7 +37,7 @@
         <div class="row p-4 border-bottom">
           <section class="col-4">
             <h6 class="mb-4 font-weight-bold">付款詳細資料</h6>
-            <a href="/#" class="btn btn-edit">編輯</a>
+            <a href="/order/delivery-method" class="btn btn-edit">編輯</a>
           </section>
           <section class="col-8 summary-content">
             <div class="col-10">
@@ -53,7 +53,7 @@
         <div class="row p-4">
           <section class="col-4">
             <h6 class="mb-4 font-weight-bold">付款詳細資料</h6>
-            <a href="/#" class="btn btn-edit">編輯</a>
+            <a href="/order/pay-method" class="btn btn-edit">編輯</a>
           </section>
           <section class="col-8 summary-content">
             <div class="col-10">

--- a/views/view.hbs
+++ b/views/view.hbs
@@ -1,1 +1,130 @@
-<p>view page</p>
+<div class="container py-5">
+  <div class="row">
+    {{!-- 主內容 --}}
+    <main class="col-8" role="main">
+      <section class="panel">
+        {{!-- 結帳步驟 step nav --}}
+        <nav class="step border-bottom px-2">
+          <ul class="nav justify-content-around">
+            <li class="px-4 py-3">1.收件地址</li>
+            <li class="px-4 py-3">2.寄件方式</li>
+            <li class="px-4 py-3">3.付款&帳單</li>
+            <li class="px-4 py-3 active">4.最後檢視</li>
+          </ul>
+        </nav>
+        {{!-- 內容表單 --}}
+        <div class="row p-4 border-bottom">
+          <section class="col-4">
+            <h6 class="mb-4 font-weight-bold">送貨地址</h6>
+            <a href="/order" class="btn btn-edit">編輯</a>
+          </section>
+          <section class="col-8 summary-content">
+            <div class="col-10">
+              <ul class="pl-0">
+                <li>姓&nbsp;明明</li>
+                <li>台灣</li>
+                <li>234</li>
+                <li>新北市</li>
+                <li>永和區</li>
+                <li>12街50巷</li>
+                <li>電話:0912345678</li>
+              </ul>
+            </div>
+          </section>
+        </div>
+        
+        {{!-- 送貨選項 --}}
+        <div class="row p-4 border-bottom">
+          <section class="col-4">
+            <h6 class="mb-4 font-weight-bold">付款詳細資料</h6>
+            <a href="/#" class="btn btn-edit">編輯</a>
+          </section>
+          <section class="col-8 summary-content">
+            <div class="col-10">
+              <ul class="pl-0">
+                <li>宅配 -</li>
+                <li>- NTD 150</li>
+              </ul>
+            </div>
+          </section>
+        </div>
+
+        {{!-- 付款詳細資訊 --}}
+        <div class="row p-4">
+          <section class="col-4">
+            <h6 class="mb-4 font-weight-bold">付款詳細資料</h6>
+            <a href="/#" class="btn btn-edit">編輯</a>
+          </section>
+          <section class="col-8 summary-content">
+            <div class="col-10">
+              <ul class="pl-0">
+                <li>信用卡付款</li>
+                <li class="my-3">
+                  <strong>帳單地址:</strong>
+                </li>
+                <li>姓&nbsp;明明</li>
+                <li>台灣</li>
+                <li>234</li>
+                <li>新北市</li>
+                <li>永和區</li>
+                <li>12街50巷</li>
+                <li>電話:0912345678</li>
+              </ul>
+              <form action="#" method="POST">
+                <button class="btn order-btn my-4">
+                  <i class="fas fa-check"></i> 確定結帳
+                </button>
+              </form>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    {{!-- 側邊攔 --}}
+    <aside class="col-4">
+      {{!-- 總金額 --}}
+      <section class="panel mb-4">
+        <h6 class="font-weight-bold border-bottom p-3">訂單合計</h6>
+        <div class="px-3 pb-3">
+          <div class="d-flex justify-content-between border-bottom py-2 font-small">
+            <span>小計:</span>
+            <span>NTD 1,000</span>
+          </div>
+          <div class="d-flex justify-content-between border-bottom py-2 font-small">
+            <span>運費:</span>
+            <span>NTD 150</span>
+          </div>
+          <div class="d-flex justify-content-between font-weight-bold py-2">
+            <span>合計:</span>
+            <span>NTD 1,150</span>
+          </div>
+        </div>
+      </section>
+      {{!-- 產品 --}}
+      <section class="panel">
+        <h6 class="font-weight-bold border-bottom p-3">配送商品</h6>
+        <div class="prod-list px-3">
+          <div class="row">
+            <div class="col-2 px-0">
+              <a href="/products/{{id}}">
+                <img src="{{Images.0.url}}" alt="product-img">
+              </a>
+            </div>
+            <div class="col-10 pl-2">
+              <a href="/products/{{id}}">
+                <h6 class="mb-3">{{name}}</h6>
+              </a>
+              <div class="font-smaller">
+                <div class="w-50 ml-auto text-left">
+                  <p>NTD 1,000 x 1 =</p>
+                  <p class="font-weight-bold">NTD 1,000</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </aside>
+  </div>
+</div>

--- a/views/view.hbs
+++ b/views/view.hbs
@@ -1,0 +1,1 @@
+<p>view page</p>


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/50958992/71711983-56f57b80-2e3e-11ea-9cf2-564e638c6335.png" width=500>

結帳流程4 之最後訂單檢視 UI 頁面。
表單功能尚未實裝。

## 內容確認
- 路由暫定為 GET "/order/view"
- 側邊欄為之前結帳頁 1 的內容
  - 加入了運費的變數
  - 新增側邊欄結帳按鈕
- 已先加入 hbs_helpers.js addDot 讓金額顯示正確格式
- 購買者資訊目前都是寫死的，之後會再修改
- 編輯按鈕可以連到相對應的頁面
  - 送貨地址 `/order`
  - 送貨選項 `/order/delivery-method`
  - 付款詳細資料 `/order/pay-method`