### PR TITLE
【加入】後台Tag CRUD功能

### DIFF
--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -27,7 +27,8 @@ module.exports = {
 
       } else {
 
-        await Tag.create(input)
+        const maxId = await Tag.max('id')
+        await Tag.create({ id: maxId + 1, ...input })
 
         req.flash('success', '新增成功！')
         res.redirect('/admin/tags')
@@ -51,10 +52,8 @@ module.exports = {
 
       } else {
 
-        const id = req.params.tagsid
-        const tag = await Tag.findByPk(id)
-
-        await tag.update(input)
+        const id = +req.params.tagsid
+        await Tag.update(input, { where: { id } })
 
         req.flash('success', '更新成功！')
         res.redirect('/admin/tags')

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -1,0 +1,15 @@
+const db = require('../../models')
+const { User } = db
+
+
+module.exports = {
+  getTags: async (req, res) => {
+    try {
+
+      res.render('admin/tags')
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+}

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -20,10 +20,19 @@ module.exports = {
   postTags: async (req, res) => {
     try {
       const input = { ...req.body }
+      if (input.name.trim() === '') {
 
-      await Tag.create(input)
+        req.flash('error', '標籤名稱不能為空白')
+        res.redirect('/admin/tags')
 
-      res.redirect('/admin/tags')
+      } else {
+
+        await Tag.create(input)
+
+        req.flash('success', '新增成功！')
+        res.redirect('/admin/tags')
+        
+      }
 
     } catch (err) {
       console.error(err)
@@ -51,18 +60,24 @@ module.exports = {
 
   putTag: async (req, res) => {
     try {
-
       const input = { ...req.body }
-      const id = req.params.tagsid
-      const tag = await Tag.findByPk(id)
 
-      await tag.update(input)
+      if (input.name.trim() === '') {
+        
+        req.flash('error', '標籤名稱不能為空白')
+        res.redirect('back')
 
-      const tags = await Tag.findAll({
-        order: [['id', 'DESC']]
-      })
+      } else {
 
-      res.render('admin/tags', { tags })
+        const id = req.params.tagsid
+        const tag = await Tag.findByPk(id)
+
+        await tag.update(input)
+
+        req.flash('success', '更新成功！')
+        res.redirect('/admin/tags')
+
+      }
 
     } catch (err) {
       console.error(err)
@@ -77,11 +92,8 @@ module.exports = {
       tag = await Tag.findByPk(id)
       await tag.destroy()
 
-      const tags = await Tag.findAll({
-        order: [['id', 'DESC']]
-      })
-
-      res.render('admin/tags', { tags })
+      req.flash('success', '刪除成功！')
+      res.redirect('/admin/tags')
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -47,7 +47,7 @@ module.exports = {
       const tag = await Tag.findByPk(id)
 
       const tags = await Tag.findAll({
-        order: [['id', 'DESC']]
+        order: [['id', 'ASC']]
       })
 
       res.render('admin/tags', { tag, tags })

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -70,4 +70,23 @@ module.exports = {
     }
   },
 
+  deleteTag: async (req, res) => {
+    try {
+
+      const id = req.params.tagsid
+      tag = await Tag.findByPk(id)
+      await tag.destroy()
+
+      const tags = await Tag.findAll({
+        order: [['id', 'DESC']]
+      })
+
+      res.render('admin/tags', { tags })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
 }

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -16,4 +16,58 @@ module.exports = {
       res.status(500).json(err.toString())
     }
   },
+
+  postTags: async (req, res) => {
+    try {
+      const input = { ...req.body }
+
+      await Tag.create(input)
+
+      res.redirect('/admin/tags')
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
+  getEditPage: async (req, res) => {
+    try {
+
+      const id = req.params.tagsid
+      const tag = await Tag.findByPk(id)
+
+      const tags = await Tag.findAll({
+        order: [['id', 'DESC']]
+      })
+
+      res.render('admin/tags', { tag, tags })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
+  putTag: async (req, res) => {
+    try {
+
+      const input = { ...req.body }
+      const id = req.params.tagsid
+      const tag = await Tag.findByPk(id)
+
+      await tag.update(input)
+
+      const tags = await Tag.findAll({
+        order: [['id', 'DESC']]
+      })
+
+      res.render('admin/tags', { tags })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
 }

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -7,7 +7,7 @@ module.exports = {
     try {
 
       const tags = await Tag.findAll({
-        order: [['id', 'DESC']]
+        order: [['id', 'ASC']]
       })
 
       res.render('admin/tags', { tags })

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -40,25 +40,6 @@ module.exports = {
     }
   },
 
-  getEditPage: async (req, res) => {
-    try {
-
-      const id = +req.params.tagsid
-
-      const tags = await Tag.findAll({
-        order: [['id', 'ASC']]
-      })
-
-      const tag = tags.find(tag => tag.id === id)
-
-      res.render('admin/tags', { tag, tags })
-
-    } catch (err) {
-      console.error(err)
-      res.status(500).json(err.toString())
-    }
-  },
-
   putTag: async (req, res) => {
     try {
       const input = { ...req.body }

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -1,12 +1,16 @@
 const db = require('../../models')
-const { User } = db
+const { Tag } = db
 
 
 module.exports = {
   getTags: async (req, res) => {
     try {
 
-      res.render('admin/tags')
+      const tags = await Tag.findAll({
+        order: [['id', 'DESC']]
+      })
+
+      res.render('admin/tags', { tags })
     } catch (err) {
       console.error(err)
       res.status(500).json(err.toString())

--- a/controllers/admin/tagCtrller.js
+++ b/controllers/admin/tagCtrller.js
@@ -31,7 +31,7 @@ module.exports = {
 
         req.flash('success', '新增成功！')
         res.redirect('/admin/tags')
-        
+
       }
 
     } catch (err) {
@@ -43,12 +43,13 @@ module.exports = {
   getEditPage: async (req, res) => {
     try {
 
-      const id = req.params.tagsid
-      const tag = await Tag.findByPk(id)
+      const id = +req.params.tagsid
 
       const tags = await Tag.findAll({
         order: [['id', 'ASC']]
       })
+
+      const tag = tags.find(tag => tag.id === id)
 
       res.render('admin/tags', { tag, tags })
 
@@ -63,7 +64,7 @@ module.exports = {
       const input = { ...req.body }
 
       if (input.name.trim() === '') {
-        
+
         req.flash('error', '標籤名稱不能為空白')
         res.redirect('back')
 
@@ -88,9 +89,8 @@ module.exports = {
   deleteTag: async (req, res) => {
     try {
 
-      const id = req.params.tagsid
-      tag = await Tag.findByPk(id)
-      await tag.destroy()
+      const id = +req.params.tagsid
+      await Tag.destroy({ where: { id } })
 
       req.flash('success', '刪除成功！')
       res.redirect('/admin/tags')

--- a/public/css/admin/admin.css
+++ b/public/css/admin/admin.css
@@ -29,3 +29,7 @@ main.container {
   flex: 1 1 auto;
   padding: 0rem;
 }
+
+input { 
+    text-align: center; 
+}

--- a/public/css/admin/admin.css
+++ b/public/css/admin/admin.css
@@ -1,3 +1,8 @@
+.alertBlock {
+  min-height: 48px;
+  max-height: 48px;
+}
+
 .container {
   max-width: 1250px;
 }

--- a/routes/admin/index.js
+++ b/routes/admin/index.js
@@ -13,5 +13,6 @@ router.get('/', (req, res) => res.redirect('/admin/products'))
 
 router.use('/products', require('./products.js'))
 router.use('/users', require('./users.js'))
+router.use('/tags', require('./tags.js'))
 
 module.exports = router

--- a/routes/admin/tags.js
+++ b/routes/admin/tags.js
@@ -4,7 +4,6 @@ const tagCtrller = require('../../controllers/admin/tagCtrller')
 // route base '/admin/tags'
 router.get('/', tagCtrller.getTags)
 router.post('/', tagCtrller.postTags)
-router.get('/:tagsid', tagCtrller.getEditPage)
 router.put('/:tagsid', tagCtrller.putTag)
 router.delete('/:tagsid', tagCtrller.deleteTag)
 

--- a/routes/admin/tags.js
+++ b/routes/admin/tags.js
@@ -3,5 +3,8 @@ const tagCtrller = require('../../controllers/admin/tagCtrller')
 
 // route base '/admin/tags'
 router.get('/', tagCtrller.getTags)
+router.post('/', tagCtrller.postTags)
+router.get('/:tagsid', tagCtrller.getEditPage)
+router.put('/:tagsid', tagCtrller.putTag)
 
 module.exports = router

--- a/routes/admin/tags.js
+++ b/routes/admin/tags.js
@@ -1,0 +1,7 @@
+const router = require('express').Router()
+const tagCtrller = require('../../controllers/admin/tagCtrller')
+
+// route base '/admin/tags'
+router.get('/', tagCtrller.getTags)
+
+module.exports = router

--- a/routes/admin/tags.js
+++ b/routes/admin/tags.js
@@ -6,5 +6,6 @@ router.get('/', tagCtrller.getTags)
 router.post('/', tagCtrller.postTags)
 router.get('/:tagsid', tagCtrller.getEditPage)
 router.put('/:tagsid', tagCtrller.putTag)
+router.delete('/:tagsid', tagCtrller.deleteTag)
 
 module.exports = router

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -2,12 +2,22 @@
   <div class="card-body pt-4">
     <div class="row col-12">
       <div class="col-6 mx-auto">
-        <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
-          <div class="form-group mx-sm-3 mb-2 mt-1">
-            <input type="text" class="form-control" name="name" placeholder="輸入新標籤...">
-          </div>
-          <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
-        </form>
+        {{#if tag}}
+          <form class="form-inline d-flex justify-content-end" action="/admin/tags/{{tag.id}}?_method=PUT"
+            method="POST">
+            <div class="form-group mx-sm-3 mb-2 mt-1">
+              <input type="text" class="form-control" name="name" placeholder="輸入標籤名稱..." value={{tag.name}}>
+            </div>
+            <button type="submit" class="btn btn-primary mb-2 mt-1">更新標籤</button>
+          </form>
+        {{else}}
+          <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
+            <div class="form-group mx-sm-3 mb-2 mt-1">
+              <input type="text" class="form-control" name="name" placeholder="輸入新標籤...">
+            </div>
+            <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
+          </form>
+        {{/if}}
         <table data-toggle="table" id="table">
           <thead>
             <tr>
@@ -23,8 +33,8 @@
                 <td>{{this.name}}</td>
                 <td>
                   <button type="button" class="btn font-weight-normal">
-                    <a href="/admin/user/{{this.id}}/edit " class="text-decoration-none text-dark "><i
-                        class="fas fa-edit" title="編輯標籤資料"></i></a>
+                    <a href="/admin/tags/{{this.id}} " class="text-decoration-none text-dark "><i class="fas fa-edit"
+                        title="編輯標籤資料"></i></a>
                   </button>
                   <!-- Delete Button trigger modal -->
                   <button type="button" class="btn font-weight-normal" data-toggle="modal"

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -38,10 +38,37 @@
                   </button>
                   <!-- Delete Button trigger modal -->
                   <button type="button" class="btn font-weight-normal" data-toggle="modal"
-                    data-target="#delete_{{this.id}}" title="刪除此會員">
+                    data-target="#delete_{{this.id}}" title="刪除此標籤">
                     <i class="far fa-trash-alt" aria-hidden="true"></i>
                   </button>
                 </td>
+                {{!-- Delete modal --}}
+                <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
+                  aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
+                  <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                          <span aria-hidden="true">&times;</span>
+                        </button>
+                      </div>
+                      <div class="modal-body">
+                        <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                          {{this.name}}</h5>
+                        </br>
+                        <h5 class="text-danger text-right">你真的要刪除這則標籤嗎？</h5>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+                        <form action="/admin/tags/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                          <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                          </button>
+                        </form>
+                      </div>
+                    </div>
+                  </div>
+                </div>
             {{/each}}
           </tbody>
         </table>

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -1,7 +1,13 @@
 <main class="container">
   <div class="card-body pt-4">
     <div class="row col-12">
-      <div class="col-6">
+      <div class="col-6 mx-auto">
+        <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
+          <div class="form-group mx-sm-3 mb-2 mt-1">
+            <input type="text" class="form-control" name="name" placeholder="輸入新標籤...">
+          </div>
+          <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
+        </form>
         <table data-toggle="table" id="table">
           <thead>
             <tr>
@@ -29,8 +35,6 @@
             {{/each}}
           </tbody>
         </table>
-      </div>
-      <div class="col-6">
       </div>
     </div>
   </div>

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -2,6 +2,9 @@
   <div class="card-body pt-4">
     <div class="row col-12">
       <div class="col-6 mx-auto">
+        <div class="alertBlock mb-2">
+          {{> alert}}
+        </div>
         {{#if tag}}
           <form class="form-inline d-flex justify-content-end" action="/admin/tags/{{tag.id}}?_method=PUT"
             method="POST">
@@ -18,7 +21,6 @@
             <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
           </form>
         {{/if}}
-        {{> alert}}
         <table data-toggle="table" id="table">
           <thead>
             <tr>
@@ -34,8 +36,8 @@
                 <td>{{this.name}}</td>
                 <td>
                   <button type="button" class="btn font-weight-normal">
-                    <a href="/admin/tags/{{this.id}} " class="text-decoration-none btn btn-outline-dark"><i class="fas fa-edit"
-                        title="編輯標籤資料"></i></a>
+                    <a href="/admin/tags/{{this.id}} " class="text-decoration-none btn btn-outline-dark"><i
+                        class="fas fa-edit" title="編輯標籤資料"></i></a>
                   </button>
                   <!-- Delete Button trigger modal -->
                   <button type="button" class="btn btn-outline-dark font-weight-normal" data-toggle="modal"

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -34,11 +34,11 @@
                 <td>{{this.name}}</td>
                 <td>
                   <button type="button" class="btn font-weight-normal">
-                    <a href="/admin/tags/{{this.id}} " class="text-decoration-none text-dark "><i class="fas fa-edit"
+                    <a href="/admin/tags/{{this.id}} " class="text-decoration-none btn btn-outline-dark"><i class="fas fa-edit"
                         title="編輯標籤資料"></i></a>
                   </button>
                   <!-- Delete Button trigger modal -->
-                  <button type="button" class="btn font-weight-normal" data-toggle="modal"
+                  <button type="button" class="btn btn-outline-dark font-weight-normal" data-toggle="modal"
                     data-target="#delete_{{this.id}}" title="刪除此標籤">
                     <i class="far fa-trash-alt" aria-hidden="true"></i>
                   </button>

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -6,14 +6,14 @@
           <form class="form-inline d-flex justify-content-end" action="/admin/tags/{{tag.id}}?_method=PUT"
             method="POST">
             <div class="form-group mx-sm-3 mb-2 mt-1">
-              <input type="text" class="form-control" name="name" placeholder="輸入標籤名稱..." value={{tag.name}}>
+              <input type="text" class="form-control" name="name" placeholder="輸入標籤名稱..." value={{tag.name}} required>
             </div>
             <button type="submit" class="btn btn-primary mb-2 mt-1">更新標籤</button>
           </form>
         {{else}}
           <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
             <div class="form-group mx-sm-3 mb-2 mt-1">
-              <input type="text" class="form-control" name="name" placeholder="輸入新標籤...">
+              <input type="text" class="form-control" name="name" placeholder="輸入新標籤..." required>
             </div>
             <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
           </form>

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -1,0 +1,1 @@
+<h1>hihi Tags!</h1>

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -5,76 +5,95 @@
         <div class="alertBlock mb-2">
           {{> alert}}
         </div>
-        {{#if tag}}
-          <form class="form-inline d-flex justify-content-end" action="/admin/tags/{{tag.id}}?_method=PUT"
-            method="POST">
-            <div class="form-group mx-sm-3 mb-2 mt-1">
-              <input type="text" class="form-control" name="name" placeholder="輸入標籤名稱..." value={{tag.name}} required>
-            </div>
-            <button type="submit" class="btn btn-primary mb-2 mt-1">更新標籤</button>
-          </form>
-        {{else}}
-          <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
-            <div class="form-group mx-sm-3 mb-2 mt-1">
-              <input type="text" class="form-control" name="name" placeholder="輸入新標籤..." required>
-            </div>
-            <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
-          </form>
-        {{/if}}
-        <table data-toggle="table" id="table">
-          <thead>
-            <tr>
-              <th data-valign="middle" class="text-center" data-sortable="true">#</th>
-              <th data-valign="middle" class="text-center" data-sortable="true">標籤名稱</th>
-              <th data-valign="middle" class="text-center">標籤操作</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{#each tags}}
+        <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
+          <div class="form-group mx-sm-3 mb-2 mt-1">
+            <input type="text" class="form-control" name="name" placeholder="輸入新標籤..." required>
+          </div>
+          <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
+        </form>
+        <div class="accordion" id="accordionEdit">
+          <table data-toggle="table" id="table">
+            <thead>
               <tr>
-                <td>{{this.id}}</td>
-                <td>{{this.name}}</td>
-                <td>
-                  <button type="button" class="btn font-weight-normal">
-                    <a href="/admin/tags/{{this.id}} " class="text-decoration-none btn btn-outline-dark"><i
-                        class="fas fa-edit" title="編輯標籤資料"></i></a>
-                  </button>
-                  <!-- Delete Button trigger modal -->
-                  <button type="button" class="btn btn-outline-dark font-weight-normal" data-toggle="modal"
-                    data-target="#delete_{{this.id}}" title="刪除此標籤">
-                    <i class="far fa-trash-alt" aria-hidden="true"></i>
-                  </button>
-                </td>
-                {{!-- Delete modal --}}
-                <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
-                  aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
-                  <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                          <span aria-hidden="true">&times;</span>
-                        </button>
-                      </div>
-                      <div class="modal-body">
-                        <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
-                          {{this.name}}</h5>
-                        </br>
-                        <h5 class="text-danger text-right">你真的要刪除這則標籤嗎？</h5>
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
-                        <form action="/admin/tags/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
-                          <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                <th data-valign="middle" class="text-center" data-sortable="true" data-width="30">#</th>
+                <th data-valign="middle" class="text-center" data-sortable="true" data-width="200">標籤名稱</th>
+                <th data-valign="middle" class="text-center" data-width="150">標籤操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{#each tags}}
+                <tr>
+                  <td>{{this.id}}</td>
+                  <td>{{this.name}}</td>
+                  <td>
+                    <button class="text-decoration-none btn btn-outline-dark mx-1" type="button" data-toggle="collapse"
+                      data-target="#collapse_{{this.id}}">
+                      <i class="fas fa-edit" title="編輯標籤資料"></i>
+                    </button>
+                    <!-- Delete Button trigger modal -->
+                    <button type="button" class="btn btn-outline-dark font-weight-normal mx-1" data-toggle="modal"
+                      data-target="#delete_{{this.id}}" title="刪除此標籤">
+                      <i class="far fa-trash-alt" aria-hidden="true"></i>
+                    </button>
+                  </td>
+                  {{!-- Delete modal --}}
+                  <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
+                    aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
+                          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
                           </button>
-                        </form>
+                        </div>
+                        <div class="modal-body">
+                          <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                            {{this.name}}</h5>
+                          </br>
+                          <h5 class="text-danger text-right">你真的要刪除這則標籤嗎？</h5>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+                          <form action="/admin/tags/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                            <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                            </button>
+                          </form>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-            {{/each}}
-          </tbody>
-        </table>
+                </tr>
+                {{!-- 更新用收合表單 --}}
+                <tr>
+                  <td class="p-0 text-center">
+                    <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                       <i class="fas fa-pen"></i>
+                    </div>
+                  </td>
+                  <td class="p-0">
+                    <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <form class="" action="/admin/tags/{{this.id}}?_method=PUT"
+                        method="POST" id="edit_{{this.id}}">
+                        <div class="form-group mx-sm-3 mb-2 mt-1">
+                          <input type="text" class="form-control" name="name" placeholder="輸入標籤名稱..."
+                            value={{this.name}} required>
+                        </div>
+                      </form>
+                    </div>
+                  </td>
+                  <td class="p-0">
+                    <div class="collapse text-center" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <button type="submit" class="btn btn-outline-dark mb-2 mt-1 px-4" form="edit_{{this.id}}">
+                        <i class="fas fa-level-down-alt fa-rotate-90"></i>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -1,1 +1,37 @@
-<h1>hihi Tags!</h1>
+<main class="container">
+  <div class="card-body pt-4">
+    <div class="row col-12">
+      <div class="col-6">
+        <table data-toggle="table" id="table">
+          <thead>
+            <tr>
+              <th data-valign="middle" class="text-center" data-sortable="true">#</th>
+              <th data-valign="middle" class="text-center" data-sortable="true">標籤名稱</th>
+              <th data-valign="middle" class="text-center">標籤操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each tags}}
+              <tr>
+                <td>{{this.id}}</td>
+                <td>{{this.name}}</td>
+                <td>
+                  <button type="button" class="btn font-weight-normal">
+                    <a href="/admin/user/{{this.id}}/edit " class="text-decoration-none text-dark "><i
+                        class="fas fa-edit" title="編輯標籤資料"></i></a>
+                  </button>
+                  <!-- Delete Button trigger modal -->
+                  <button type="button" class="btn font-weight-normal" data-toggle="modal"
+                    data-target="#delete_{{this.id}}" title="刪除此會員">
+                    <i class="far fa-trash-alt" aria-hidden="true"></i>
+                  </button>
+                </td>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+      <div class="col-6">
+      </div>
+    </div>
+  </div>
+</main>

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -18,6 +18,7 @@
             <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
           </form>
         {{/if}}
+        {{> alert}}
         <table data-toggle="table" id="table">
           <thead>
             <tr>

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -43,7 +43,7 @@
         </li>
         <br>
       </ul>
-      <a class="btn btn-outline-secondary ml-3" href="/signout">登出</a>
+      <a class="btn btn-outline-secondary ml-3" href="/users/signout">登出</a>
     </div>
   </nav>
   {{{body}}}

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -38,6 +38,9 @@
         <li class="nav-item">
           <a class="nav-link {{#ifEqual path '/users'}}active{{/ifEqual}}" href="/admin/users">會員</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link {{#ifEqual path '/tags'}}active{{/ifEqual}}" href="/admin/tags">標籤</a>
+        </li>
         <br>
       </ul>
       <a class="btn btn-outline-secondary ml-3" href="/signout">登出</a>


### PR DESCRIPTION
<img width="1439" alt="螢幕快照 2020-01-04 下午4 07 49" src="https://user-images.githubusercontent.com/49901777/71762619-6d6a0880-2f0c-11ea-8c04-6e31a369b379.png">

## 手動測試
- 登入使用者帳號進入後台可以看到標籤頁面
- 標籤頁面可以看到目前資料庫中的所有標籤
- 可以新增一筆標籤
- 點選編輯標籤，標籤名稱會帶入上方input欄位
- 點擊更新標籤按鈕後，會更新標籤並重新導向回所有標籤
- 點選刪除標籤按鈕，會跳出modal再次確認
- 點選確認刪除，會刪除該標籤並重新導向回所有標籤
- 新增與編輯功能有前後端防空白功能
