### PR TITLE
【加入】後台category CRUD功能

### DIFF
--- a/controllers/admin/categoryCtrller.js
+++ b/controllers/admin/categoryCtrller.js
@@ -5,10 +5,12 @@ const { Category } = db
 module.exports = {
   getCategories: async (req, res) => {
     try {
-      
-    
 
-    res.render('admin/categories')
+      const categories = await Category.findAll({
+        order: [['id', 'DESC']]
+      })
+
+      res.render('admin/categories', { categories })
     } catch (err) {
       console.error(err)
       res.status(500).json({ status: 'serverError', message: err.toString() })

--- a/controllers/admin/categoryCtrller.js
+++ b/controllers/admin/categoryCtrller.js
@@ -7,7 +7,7 @@ module.exports = {
     try {
 
       const categories = await Category.findAll({
-        order: [['id', 'DESC']]
+        order: [['id', 'ASC']]
       })
 
       res.render('admin/categories', { categories })
@@ -27,7 +27,8 @@ module.exports = {
 
       } else {
 
-        await Category.create(input)
+        const maxId = await Category.max('id')
+        await Category.create({ id: maxId + 1, ...input })
 
         req.flash('success', '新增成功！')
         res.redirect('/admin/categories')
@@ -43,12 +44,13 @@ module.exports = {
   getEditPage: async (req, res) => {
     try {
 
-      const id = req.params.categoriesid
-      const category = await Category.findByPk(id)
+      const id = +req.params.categoriesid
 
       const categories = await Category.findAll({
-        order: [['id', 'DESC']]
+        order: [['id', 'ASC']]
       })
+
+      const category = categories.find(category => category.id === id)
 
       res.render('admin/categories', { category, categories })
 
@@ -69,10 +71,8 @@ module.exports = {
 
       } else {
 
-        const id = req.params.categoriesid
-        const category = await Category.findByPk(id)
-
-        await category.update(input)
+        const id = +req.params.categoriesid
+        await Category.update(input, { where: { id } })
 
         req.flash('success', '更新成功！')
         res.redirect('/admin/categories')
@@ -88,9 +88,8 @@ module.exports = {
   deleteCategory: async (req, res) => {
     try {
 
-      const id = req.params.categoriesid
-      category = await Category.findByPk(id)
-      await category.destroy()
+      const id = +req.params.categoriesid
+      await Category.destroy({ where: { id } })
 
       req.flash('success', '刪除成功！')
       res.redirect('/admin/categories')

--- a/controllers/admin/categoryCtrller.js
+++ b/controllers/admin/categoryCtrller.js
@@ -41,25 +41,6 @@ module.exports = {
     }
   },
 
-  getEditPage: async (req, res) => {
-    try {
-
-      const id = +req.params.categoriesid
-
-      const categories = await Category.findAll({
-        order: [['id', 'ASC']]
-      })
-
-      const category = categories.find(category => category.id === id)
-
-      res.render('admin/categories', { category, categories })
-
-    } catch (err) {
-      console.error(err)
-      res.status(500).json(err.toString())
-    }
-  },
-
   putCategory: async (req, res) => {
     try {
       const input = { ...req.body }

--- a/controllers/admin/categoryCtrller.js
+++ b/controllers/admin/categoryCtrller.js
@@ -1,0 +1,17 @@
+const db = require('../../models')
+const { Category } = db
+
+
+module.exports = {
+  getCategories: async (req, res) => {
+    try {
+      
+    
+
+    res.render('admin/categories')
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  },
+}

--- a/controllers/admin/categoryCtrller.js
+++ b/controllers/admin/categoryCtrller.js
@@ -49,7 +49,7 @@ module.exports = {
       const categories = await Category.findAll({
         order: [['id', 'DESC']]
       })
-      console.log(category)
+
       res.render('admin/categories', { category, categories })
 
     } catch (err) {

--- a/controllers/admin/categoryCtrller.js
+++ b/controllers/admin/categoryCtrller.js
@@ -16,4 +16,89 @@ module.exports = {
       res.status(500).json({ status: 'serverError', message: err.toString() })
     }
   },
+
+  postCategories: async (req, res) => {
+    try {
+      const input = { ...req.body }
+      if (input.name.trim() === '') {
+
+        req.flash('error', '分類名稱不能為空白')
+        res.redirect('/admin/categories')
+
+      } else {
+
+        await Category.create(input)
+
+        req.flash('success', '新增成功！')
+        res.redirect('/admin/categories')
+
+      }
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
+  getEditPage: async (req, res) => {
+    try {
+
+      const id = req.params.categoriesid
+      const category = await Category.findByPk(id)
+
+      const categories = await Category.findAll({
+        order: [['id', 'DESC']]
+      })
+      console.log(category)
+      res.render('admin/categories', { category, categories })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
+  putCategory: async (req, res) => {
+    try {
+      const input = { ...req.body }
+
+      if (input.name.trim() === '') {
+
+        req.flash('error', '分類名稱不能為空白')
+        res.redirect('back')
+
+      } else {
+
+        const id = req.params.categoriesid
+        const category = await Category.findByPk(id)
+
+        await category.update(input)
+
+        req.flash('success', '更新成功！')
+        res.redirect('/admin/categories')
+
+      }
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
+  deleteCategory: async (req, res) => {
+    try {
+
+      const id = req.params.categoriesid
+      category = await Category.findByPk(id)
+      await category.destroy()
+
+      req.flash('success', '刪除成功！')
+      res.redirect('/admin/categories')
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
 }

--- a/public/css/admin/admin.css
+++ b/public/css/admin/admin.css
@@ -28,3 +28,7 @@ main.container {
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
 }
+
+input { 
+    text-align: center; 
+}

--- a/public/css/admin/admin.css
+++ b/public/css/admin/admin.css
@@ -1,3 +1,8 @@
+.alertBlock {
+  min-height: 48px;
+  max-height: 48px;
+}
+
 .container {
   max-width: 1250px;
 }

--- a/routes/admin/categories.js
+++ b/routes/admin/categories.js
@@ -1,0 +1,7 @@
+const router = require('express').Router()
+const categoryCtrller = require('../../controllers/admin/categoryCtrller')
+
+// route base '/admin/categories'
+router.get('/', categoryCtrller.getCategories)
+
+module.exports = router

--- a/routes/admin/categories.js
+++ b/routes/admin/categories.js
@@ -4,7 +4,6 @@ const categoryCtrller = require('../../controllers/admin/categoryCtrller')
 // route base '/admin/categories'
 router.get('/', categoryCtrller.getCategories)
 router.post('/', categoryCtrller.postCategories)
-router.get('/:categoriesid', categoryCtrller.getEditPage)
 router.put('/:categoriesid', categoryCtrller.putCategory)
 router.delete('/:categoriesid', categoryCtrller.deleteCategory)
 

--- a/routes/admin/categories.js
+++ b/routes/admin/categories.js
@@ -3,5 +3,9 @@ const categoryCtrller = require('../../controllers/admin/categoryCtrller')
 
 // route base '/admin/categories'
 router.get('/', categoryCtrller.getCategories)
+router.post('/', categoryCtrller.postCategories)
+router.get('/:categoriesid', categoryCtrller.getEditPage)
+router.put('/:categoriesid', categoryCtrller.putCategory)
+router.delete('/:categoriesid', categoryCtrller.deleteCategory)
 
 module.exports = router

--- a/routes/admin/index.js
+++ b/routes/admin/index.js
@@ -14,5 +14,6 @@ router.get('/', (req, res) => res.redirect('/admin/products'))
 router.use('/products', require('./products.js'))
 router.use('/users', require('./users.js'))
 router.use('/orders', require('./orders.js'))
+router.use('/categories', require('./categories.js'))
 
 module.exports = router

--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -5,78 +5,94 @@
         <div class="alertBlock mb-2">
           {{> alert}}
         </div>
-        {{#if category}}
-          <form class="form-inline d-flex justify-content-end" action="/admin/categories/{{category.id}}?_method=PUT"
-            method="POST">
-            <div class="form-group mx-sm-3 mb-2 mt-1">
-              <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..." value={{category.name}}
-                required>
-            </div>
-            <button type="submit" class="btn btn-primary mb-2 mt-1">更新分類</button>
-          </form>
-        {{else}}
-          <form class="form-inline d-flex justify-content-end" action="/admin/categories" method="POST">
-            <div class="form-group mx-sm-3 mb-2 mt-1">
-              <input type="text" class="form-control" name="name" placeholder="輸入新分類..." required>
-            </div>
-            <button type="submit" class="btn btn-primary mb-2 mt-1">新增分類</button>
-          </form>
-        {{/if}}
-        <table data-toggle="table" id="table">
-          <thead>
-            <tr>
-              <th data-valign="middle" class="text-center" data-sortable="true">#</th>
-              <th data-valign="middle" class="text-center" data-sortable="true">分類名稱</th>
-              <th data-valign="middle" class="text-center">分類操作</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{#each categories}}
+        <form class="form-inline d-flex justify-content-end" action="/admin/categories" method="POST">
+          <div class="form-group mx-sm-3 mb-2 mt-1">
+            <input type="text" class="form-control" name="name" placeholder="輸入新分類..." required>
+          </div>
+          <button type="submit" class="btn btn-primary mb-2 mt-1">新增分類</button>
+        </form>
+        <div class="accordion" id="accordionEdit">
+          <table data-toggle="table" id="table">
+            <thead>
               <tr>
-                <td>{{this.id}}</td>
-                <td>{{this.name}}</td>
-                <td>
-                  <button type="button" class="btn font-weight-normal">
-                    <a href="/admin/categories/{{this.id}} " class="text-decoration-none btn btn-outline-dark"><i
-                        class="fas fa-edit" title="編輯分類資料"></i></a>
-                  </button>
-                  <!-- Delete Button trigger modal -->
-                  <button type="button" class="btn btn-outline-dark font-weight-normal" data-toggle="modal"
-                    data-target="#delete_{{this.id}}" title="刪除此分類">
-                    <i class="far fa-trash-alt" aria-hidden="true"></i>
-                  </button>
-                </td>
-                {{!-- Delete modal --}}
-                <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
-                  aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
-                  <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                          <span aria-hidden="true">&times;</span>
-                        </button>
-                      </div>
-                      <div class="modal-body">
-                        <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
-                          {{this.name}}</h5>
-                        </br>
-                        <h5 class="text-danger text-right">你真的要刪除這則分類嗎？</h5>
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
-                        <form action="/admin/categories/{{this.id}}?_method=DELETE" method="POST"
-                          style="display: inline;">
-                          <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                <th data-valign="middle" class="text-center" data-sortable="true" data-width="30">#</th>
+                <th data-valign="middle" class="text-center" data-sortable="true" data-width="200">分類名稱</th>
+                <th data-valign="middle" class="text-center" data-width="150">分類操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{#each categories}}
+                <tr>
+                  <td>{{this.id}}</td>
+                  <td>{{this.name}}</td>
+                  <td>
+                    <button class="text-decoration-none btn btn-outline-dark mx-1" type="button" data-toggle="collapse"
+                      data-target="#collapse_{{this.id}}">
+                      <i class="fas fa-edit" title="編輯分類資料"></i>
+                    </button>
+                    <!-- Delete Button trigger modal -->
+                    <button type="button" class="btn btn-outline-dark font-weight-normal mx-1" data-toggle="modal"
+                      data-target="#delete_{{this.id}}" title="刪除此分類">
+                      <i class="far fa-trash-alt" aria-hidden="true"></i>
+                    </button>
+                  </td>
+                  {{!-- Delete modal --}}
+                  <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
+                    aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
+                          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
                           </button>
-                        </form>
+                        </div>
+                        <div class="modal-body">
+                          <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                            {{this.name}}</h5>
+                          </br>
+                          <h5 class="text-danger text-right">你真的要刪除這則分類嗎？</h5>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+                          <form action="/admin/categories/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                            <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                            </button>
+                          </form>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-            {{/each}}
-          </tbody>
-        </table>
+                </tr>
+                {{!-- 更新用收合表單 --}}
+                <tr>
+                  <td class="p-0 text-center">
+                    <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <i class="fas fa-pen"></i>
+                    </div>
+                  </td>
+                  <td class="p-0">
+                    <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <form class="" action="/admin/categories/{{this.id}}?_method=PUT" method="POST" id="edit_{{this.id}}">
+                        <div class="form-group mx-sm-3 mb-2 mt-1">
+                          <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..."
+                            value={{this.name}} required>
+                        </div>
+                      </form>
+                    </div>
+                  </td>
+                  <td class="p-0">
+                    <div class="collapse text-center" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <button type="submit" class="btn btn-outline-dark mb-2 mt-1 px-4" form="edit_{{this.id}}">
+                        <i class="fas fa-level-down-alt fa-rotate-90"></i>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -2,11 +2,15 @@
   <div class="card-body pt-4">
     <div class="row col-12">
       <div class="col-6 mx-auto">
+        <div class="alertBlock mb-2">
+          {{> alert}}
+        </div>
         {{#if category}}
           <form class="form-inline d-flex justify-content-end" action="/admin/categories/{{category.id}}?_method=PUT"
             method="POST">
             <div class="form-group mx-sm-3 mb-2 mt-1">
-              <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..." value={{category.name}} required>
+              <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..." value={{category.name}}
+                required>
             </div>
             <button type="submit" class="btn btn-primary mb-2 mt-1">更新分類</button>
           </form>
@@ -18,7 +22,6 @@
             <button type="submit" class="btn btn-primary mb-2 mt-1">新增分類</button>
           </form>
         {{/if}}
-        {{> alert}}
         <table data-toggle="table" id="table">
           <thead>
             <tr>
@@ -62,7 +65,8 @@
                       </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
-                        <form action="/admin/categories/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                        <form action="/admin/categories/{{this.id}}?_method=DELETE" method="POST"
+                          style="display: inline;">
                           <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
                           </button>
                         </form>

--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -2,16 +2,16 @@
   <div class="card-body pt-4">
     <div class="row col-12">
       <div class="col-6 mx-auto">
-        {{#if tag}}
-          <form class="form-inline d-flex justify-content-end" action="/admin/tags/{{tag.id}}?_method=PUT"
+        {{#if category}}
+          <form class="form-inline d-flex justify-content-end" action="/admin/categories/{{category.id}}?_method=PUT"
             method="POST">
             <div class="form-group mx-sm-3 mb-2 mt-1">
-              <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..." value={{tag.name}} required>
+              <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..." value={{category.name}} required>
             </div>
             <button type="submit" class="btn btn-primary mb-2 mt-1">更新分類</button>
           </form>
         {{else}}
-          <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
+          <form class="form-inline d-flex justify-content-end" action="/admin/categories" method="POST">
             <div class="form-group mx-sm-3 mb-2 mt-1">
               <input type="text" class="form-control" name="name" placeholder="輸入新分類..." required>
             </div>
@@ -34,7 +34,7 @@
                 <td>{{this.name}}</td>
                 <td>
                   <button type="button" class="btn font-weight-normal">
-                    <a href="/admin/tags/{{this.id}} " class="text-decoration-none btn btn-outline-dark"><i
+                    <a href="/admin/categories/{{this.id}} " class="text-decoration-none btn btn-outline-dark"><i
                         class="fas fa-edit" title="編輯分類資料"></i></a>
                   </button>
                   <!-- Delete Button trigger modal -->
@@ -62,7 +62,7 @@
                       </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
-                        <form action="/admin/tags/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                        <form action="/admin/categories/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
                           <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
                           </button>
                         </form>

--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -1,0 +1,1 @@
+<h1>admin category page</h1>

--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -1,1 +1,79 @@
-<h1>admin category page</h1>
+<main class="container">
+  <div class="card-body pt-4">
+    <div class="row col-12">
+      <div class="col-6 mx-auto">
+        {{#if tag}}
+          <form class="form-inline d-flex justify-content-end" action="/admin/tags/{{tag.id}}?_method=PUT"
+            method="POST">
+            <div class="form-group mx-sm-3 mb-2 mt-1">
+              <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..." value={{tag.name}} required>
+            </div>
+            <button type="submit" class="btn btn-primary mb-2 mt-1">更新分類</button>
+          </form>
+        {{else}}
+          <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
+            <div class="form-group mx-sm-3 mb-2 mt-1">
+              <input type="text" class="form-control" name="name" placeholder="輸入新分類..." required>
+            </div>
+            <button type="submit" class="btn btn-primary mb-2 mt-1">新增分類</button>
+          </form>
+        {{/if}}
+        {{> alert}}
+        <table data-toggle="table" id="table">
+          <thead>
+            <tr>
+              <th data-valign="middle" class="text-center" data-sortable="true">#</th>
+              <th data-valign="middle" class="text-center" data-sortable="true">分類名稱</th>
+              <th data-valign="middle" class="text-center">分類操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each categories}}
+              <tr>
+                <td>{{this.id}}</td>
+                <td>{{this.name}}</td>
+                <td>
+                  <button type="button" class="btn font-weight-normal">
+                    <a href="/admin/tags/{{this.id}} " class="text-decoration-none btn btn-outline-dark"><i
+                        class="fas fa-edit" title="編輯分類資料"></i></a>
+                  </button>
+                  <!-- Delete Button trigger modal -->
+                  <button type="button" class="btn btn-outline-dark font-weight-normal" data-toggle="modal"
+                    data-target="#delete_{{this.id}}" title="刪除此分類">
+                    <i class="far fa-trash-alt" aria-hidden="true"></i>
+                  </button>
+                </td>
+                {{!-- Delete modal --}}
+                <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
+                  aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
+                  <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                          <span aria-hidden="true">&times;</span>
+                        </button>
+                      </div>
+                      <div class="modal-body">
+                        <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                          {{this.name}}</h5>
+                        </br>
+                        <h5 class="text-danger text-right">你真的要刪除這則分類嗎？</h5>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+                        <form action="/admin/tags/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                          <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                          </button>
+                        </form>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</main>

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -38,6 +38,9 @@
         <li class="nav-item">
           <a class="nav-link {{#ifEqual path '/users'}}active{{/ifEqual}}" href="/admin/users">會員</a>
         </li>
+            <li class="nav-item">
+              <a class="nav-link {{#ifEqual path '/categories'}}active{{/ifEqual}}" href="/admin/categories">分類</a>
+            </li>
         <br>
       </ul>
       <a class="btn btn-outline-secondary ml-3" href="/signout">登出</a>


### PR DESCRIPTION
<img width="1439" alt="螢幕快照 2020-01-06 上午12 07 24" src="https://user-images.githubusercontent.com/49901777/71782744-895ad080-3018-11ea-988b-4a6eb35c19ac.png">

## 手動測試
- 登入使用者帳號進入後台可以看到分類頁面
- 分類頁面可以看到目前資料庫中的所有分類
- 可以新增一筆分類
- 點選編輯分類，分類名稱會帶入上方input欄位
- 點擊更新分類按鈕後，會更新分類並重新導向回所有分類
- 點選刪除分類按鈕，會跳出modal再次確認
- 點選確認刪除，會刪除該分類並重新導向回所有分類
- 新增與編輯功能有前後端防空白功能