### PR TITLE
【優化】前台使用者訂單一覽

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# DB config
+MYSQL_USER=user_name
+MYSQL_KEY=password
+MYSQL_DATABASE=db_name
+MYSQL_DATABASE_TEST=db_test_name
+MYSQL_HOST=host_IP
+
+# Imgur API
+IMGUR_CLIENT_ID=
+
+# Gmail config
+GMAIL_USER=
+GMAIL_KEY=
+
+# newebpay API
+HOST_URL=from_ngrok
+MERCHANT_ID=newebpay_ID
+HASH_KEY=newebpay_KEY
+HASH_IV=newebpay_IV

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ typings/
 # multer
 temp/
 upload/
+
+# dev tools
+ngrok.exe

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ upload/
 
 # dev tools
 ngrok.exe
+ngrok

--- a/config/newebpay.js
+++ b/config/newebpay.js
@@ -1,0 +1,52 @@
+require('dotenv').config()
+const { aesEncrypt, shaHash } = require('../lib/tools.js')
+
+// 藍新金流設定
+const host = process.env.HOST_URL
+const MerchantID = process.env.MERCHANT_ID
+const HashKey = process.env.HASH_KEY
+const HashIV = process.env.HASH_IV
+const PayGateWay = "https://ccore.newebpay.com/MPG/mpg_gateway"
+const ReturnURL = `${host}/newebpay/callback?from=ReturnURL`
+const NotifyURL = `${host}/newebpay/callback?from=NotifyURL`
+const ClientBackURL = `${host}/orders`
+
+function getTradeInfo(amount, desc, email) {
+  data = {
+    'MerchantID': MerchantID,         // 商店代號
+    'RespondType': 'JSON',            // 回傳格式
+    'TimeStamp': Date.now(),          // 時間戳記
+    'Version': 1.5,                   // 串接程式版本
+    'MerchantOrderNo': Date.now(),    // 商店訂單編號
+    'LoginType': 0,                   // 智付通會員
+    'OrderComment': 'OrderComment',   // 商店備註
+    'Amt': amount,                    // 訂單金額
+    'ItemDesc': desc,                 // 產品名稱
+    'Email': email,                   // 付款人電子信箱
+    'ReturnURL': ReturnURL,           // 支付完成返回商店網址
+    'NotifyURL': NotifyURL,           // 支付通知網址/每期授權結果通知
+    'ClientBackURL': ClientBackURL    // 支付取消返回商店網址
+  }
+
+  console.log('data')
+  console.log(data)
+
+  const TradeInfo = aesEncrypt(data, HashKey, HashIV)
+  const TradeSha = shaHash(TradeInfo, HashKey, HashIV)
+
+  tradeInfo = {
+    'MerchantID': MerchantID,    // 商店代號
+    'TradeInfo': TradeInfo,      // 加密後參數
+    'TradeSha': TradeSha,
+    'Version': 1.5,              // 串接程式版本
+    'PayGateWay': PayGateWay,
+    'MerchantOrderNo': data.MerchantOrderNo,
+  }
+
+  console.log('tradeInfo')
+  console.log(tradeInfo)
+
+  return tradeInfo
+}
+
+module.exports = getTradeInfo

--- a/config/newebpay.js
+++ b/config/newebpay.js
@@ -8,7 +8,7 @@ const HashIV = process.env.HASH_IV
 const PayGateWay = "https://ccore.newebpay.com/MPG/mpg_gateway"
 const ReturnURL = `${host}/newebpay/callback?from=ReturnURL`
 const NotifyURL = `${host}/newebpay/callback?from=NotifyURL`
-const ClientBackURL = `${host}/users/orders`
+const ClientBackURL = `${host}/orders`
 
 function getTradeInfo(orderNo, amount, desc, email) {
   data = {
@@ -28,8 +28,6 @@ function getTradeInfo(orderNo, amount, desc, email) {
     'ClientBackURL': ClientBackURL    // 支付取消返回商店網址
   }
 
-  console.log('data', data)
-
   const TradeInfo = aesEncrypt(data, HashKey, HashIV)
   const TradeSha = shaHash(TradeInfo, HashKey, HashIV)
 
@@ -41,8 +39,6 @@ function getTradeInfo(orderNo, amount, desc, email) {
     'PayGateWay': PayGateWay,
     'MerchantOrderNo': data.MerchantOrderNo,
   }
-
-  console.log('tradeInfo', tradeInfo)
 
   return tradeInfo
 }

--- a/config/newebpay.js
+++ b/config/newebpay.js
@@ -10,13 +10,13 @@ const ReturnURL = `${host}/newebpay/callback?from=ReturnURL`
 const NotifyURL = `${host}/newebpay/callback?from=NotifyURL`
 const ClientBackURL = `${host}/users/orders`
 
-function getTradeInfo(sn, amount, desc, email) {
+function getTradeInfo(orderNo, amount, desc, email) {
   data = {
     'MerchantID': MerchantID,         // 商店代號
     'RespondType': 'JSON',            // 回傳格式
     'TimeStamp': Date.now(),          // 時間戳記
     'Version': 1.5,                   // 串接程式版本
-    'MerchantOrderNo': sn,    // 商店訂單編號
+    'MerchantOrderNo': orderNo,       // 商店訂單編號
     'LoginType': 0,                   // 智付通會員
     'OrderComment': 
       '此為測試金流，請勿輸入您的真實信用卡內容。測試用卡號 4000-2211-1111-1111，其餘可亂填',   // 商店備註

--- a/config/newebpay.js
+++ b/config/newebpay.js
@@ -7,9 +7,9 @@ const MerchantID = process.env.MERCHANT_ID
 const HashKey = process.env.HASH_KEY
 const HashIV = process.env.HASH_IV
 const PayGateWay = "https://ccore.newebpay.com/MPG/mpg_gateway"
-const ReturnURL = `${host}/newebpay/callback?from=ReturnURL`
-const NotifyURL = `${host}/newebpay/callback?from=NotifyURL`
-const ClientBackURL = `${host}/orders`
+const ReturnURL = `${host}/orders/newebpay/callback?from=ReturnURL`
+const NotifyURL = `${host}/orders/newebpay/callback?from=NotifyURL`
+const ClientBackURL = `${host}/users/orders`
 
 function getTradeInfo(amount, desc, email) {
   data = {
@@ -19,7 +19,8 @@ function getTradeInfo(amount, desc, email) {
     'Version': 1.5,                   // 串接程式版本
     'MerchantOrderNo': Date.now(),    // 商店訂單編號
     'LoginType': 0,                   // 智付通會員
-    'OrderComment': 'OrderComment',   // 商店備註
+    'OrderComment': 
+      '此為測試金流，請勿輸入您的真實信用卡內容。測試用卡號 4000-2211-1111-1111，其餘可亂填',   // 商店備註
     'Amt': amount,                    // 訂單金額
     'ItemDesc': desc,                 // 產品名稱
     'Email': email,                   // 付款人電子信箱
@@ -28,8 +29,7 @@ function getTradeInfo(amount, desc, email) {
     'ClientBackURL': ClientBackURL    // 支付取消返回商店網址
   }
 
-  console.log('data')
-  console.log(data)
+  console.log('data', data)
 
   const TradeInfo = aesEncrypt(data, HashKey, HashIV)
   const TradeSha = shaHash(TradeInfo, HashKey, HashIV)
@@ -43,8 +43,7 @@ function getTradeInfo(amount, desc, email) {
     'MerchantOrderNo': data.MerchantOrderNo,
   }
 
-  console.log('tradeInfo')
-  console.log(tradeInfo)
+  console.log('tradeInfo', tradeInfo)
 
   return tradeInfo
 }

--- a/config/newebpay.js
+++ b/config/newebpay.js
@@ -1,4 +1,3 @@
-require('dotenv').config()
 const { aesEncrypt, shaHash } = require('../lib/tools.js')
 
 // 藍新金流設定
@@ -7,17 +6,17 @@ const MerchantID = process.env.MERCHANT_ID
 const HashKey = process.env.HASH_KEY
 const HashIV = process.env.HASH_IV
 const PayGateWay = "https://ccore.newebpay.com/MPG/mpg_gateway"
-const ReturnURL = `${host}/orders/newebpay/callback?from=ReturnURL`
-const NotifyURL = `${host}/orders/newebpay/callback?from=NotifyURL`
+const ReturnURL = `${host}/newebpay/callback?from=ReturnURL`
+const NotifyURL = `${host}/newebpay/callback?from=NotifyURL`
 const ClientBackURL = `${host}/users/orders`
 
-function getTradeInfo(amount, desc, email) {
+function getTradeInfo(sn, amount, desc, email) {
   data = {
     'MerchantID': MerchantID,         // 商店代號
     'RespondType': 'JSON',            // 回傳格式
     'TimeStamp': Date.now(),          // 時間戳記
     'Version': 1.5,                   // 串接程式版本
-    'MerchantOrderNo': Date.now(),    // 商店訂單編號
+    'MerchantOrderNo': sn,    // 商店訂單編號
     'LoginType': 0,                   // 智付通會員
     'OrderComment': 
       '此為測試金流，請勿輸入您的真實信用卡內容。測試用卡號 4000-2211-1111-1111，其餘可亂填',   // 商店備註

--- a/config/newebpay.js
+++ b/config/newebpay.js
@@ -10,13 +10,13 @@ const ReturnURL = `${host}/newebpay/callback?from=ReturnURL`
 const NotifyURL = `${host}/newebpay/callback?from=NotifyURL`
 const ClientBackURL = `${host}/orders`
 
-function getTradeInfo(orderNo, amount, desc, email) {
+function getTradeInfo(amount, desc, email) {
   data = {
     'MerchantID': MerchantID,         // 商店代號
     'RespondType': 'JSON',            // 回傳格式
     'TimeStamp': Date.now(),          // 時間戳記
     'Version': 1.5,                   // 串接程式版本
-    'MerchantOrderNo': orderNo,       // 商店訂單編號
+    'MerchantOrderNo': Date.now(),    // 商店訂單編號
     'LoginType': 0,                   // 智付通會員
     'OrderComment': 
       '此為測試金流，請勿輸入您的真實信用卡內容。測試用卡號 4000-2211-1111-1111，其餘可亂填',   // 商店備註

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -260,7 +260,8 @@ module.exports = {
         where: { orderNo: tradeInfo.Result.MerchantOrderNo },
         defaults: {
           OrderId: order.id,
-          status: tradeInfo.Status,
+          status: tradeInfo.Status === 'SUCCESS' ? true : false,
+          code: tradeInfo.Status,
           msg: tradeInfo.Message,
           tradeNo: tradeInfo.Result.TradeNo,
           payTime: payTime

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -28,10 +28,9 @@ module.exports = {
         order.sumPrice = order.amount - order.Delivery.price
         order.products.forEach(product => {
           product.mainImg = product.Images.find(img => img.isMain).url
-          product.subPrice = product.OrderItem.quantity * product.price 
+          product.subPrice = product.OrderItem.quantity * product.price
         })
       })
-
       res.render('orders', { orders, css: 'profile' })
 
     } catch (err) {

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -28,7 +28,7 @@ module.exports = {
         order.sumPrice = order.amount - order.Delivery.price
         order.products.forEach(product => {
           product.mainImg = product.Images.find(img => img.isMain).url
-          product.subPrice = product.OrderItem.quantity * product.price
+          product.subPrice = product.OrderItem.quantity * product.OrderItem.price
         })
       })
       res.render('orders', { orders, css: 'profile' })

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -25,11 +25,9 @@ module.exports = {
 
       orders.forEach(order => {
         order.createdTime = order.createdAt.toJSON().split('T')[0]
-        order.amountFormat = order.amount.toLocaleString()
         order.sumPrice = order.amount - order.Delivery.price
         order.products.forEach(product => {
           product.mainImg = product.Images.find(img => img.isMain).url
-          product.orderPrice = product.OrderItem.price.toLocaleString()
           product.subPrice = product.OrderItem.quantity * product.price 
         })
       })

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -2,11 +2,7 @@ const db = require('../models')
 const { Cart, CartItem, Order, OrderItem, Delivery } = db
 
 const { checkCheckout1 } = require('../lib/checker.js')
-const { genDataChain, aesEncrypt, aesDecrypt, shaHash } = require('../lib/tools.js')
-
-// 藍新金流設定
-const HashKey = process.env.HASH_KEY
-const HashIV = process.env.HASH_IV
+const getTradeInfo = require('../config/newebpay.js')
 
 module.exports = {
   async setCheckout(req, res) {
@@ -200,5 +196,28 @@ module.exports = {
       console.error(err)
       res.status(500).json({ status: 'serverError', message: err.toString() })
     }
-  }
+  },
+
+  async getPayment(req, res) {
+    try {
+      console.log('===== getPayment =====')
+      console.log(req.params.id)
+
+      const order = await Order.findByPk(req.params.id)
+      getTradeInfo(100, '商品', 'email')
+      res.render('payment', { order })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  },
+
+  newebpayCb(req, res) {
+    console.log('===== spgatewayCallback =====')
+    console.log(req.body)
+    console.log('==========')
+
+    return res.redirect('back')
+  },
 }

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -261,7 +261,7 @@ module.exports = {
 
       const tradeInfo = getTradeInfo(orderNo, order.amount, prodNames, req.user.email)
 
-      res.render('payment', { order, tradeInfo })
+      res.render('payment', { tradeInfo, layout: false })
 
     } catch (err) {
       console.error(err)

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -2,6 +2,11 @@ const db = require('../models')
 const { Cart, CartItem, Order, OrderItem, Delivery } = db
 
 const { checkCheckout1 } = require('../lib/checker.js')
+const { genDataChain, aesEncrypt, aesDecrypt, shaHash } = require('../lib/tools.js')
+
+// 藍新金流設定
+const HashKey = process.env.HASH_KEY
+const HashIV = process.env.HASH_IV
 
 module.exports = {
   async setCheckout(req, res) {

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -203,9 +203,16 @@ module.exports = {
       console.log('===== getPayment =====')
       console.log(req.params.id)
 
-      const order = await Order.findByPk(req.params.id)
-      getTradeInfo(100, '商品', 'email')
-      res.render('payment', { order })
+      const order = await Order.findByPk(req.params.id, {
+        include: [{ 
+          association: 'products',
+          attributes: ['name'] 
+        }]
+      })
+      const prodNames = order.products.map(prod => prod.name).join(', ')
+
+      const tradeInfo = getTradeInfo(order.amount, prodNames, req.user.email)
+      res.render('payment', { order, tradeInfo })
 
     } catch (err) {
       console.error(err)

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -16,19 +16,21 @@ module.exports = {
       const orders = await Order.findAll({
         where: { user_id: req.user.id },
         order: [['id', 'DESC']],
-        include: {
+        include: [{
           association: 'products',
           include: ['Gifts', 'Images']
-        }
+        }, 
+        'Delivery']
       })
 
       orders.forEach(order => {
         order.createdTime = order.createdAt.toJSON().split('T')[0]
         order.amountFormat = order.amount.toLocaleString()
+        order.sumPrice = order.amount - order.Delivery.price
         order.products.forEach(product => {
           product.mainImg = product.Images.find(img => img.isMain).url
           product.orderPrice = product.OrderItem.price.toLocaleString()
-          product.subPrice = product.OrderItem.quantity * product.price
+          product.subPrice = product.OrderItem.quantity * product.price 
         })
       })
 

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -1,7 +1,7 @@
 const bcrypt = require('bcryptjs')
 const passport = require('passport')
 const db = require('../models')
-const { User, Order, Product } = db
+const { User } = db
 
 const { checkSignUp } = require('../lib/checker.js')
 
@@ -53,36 +53,5 @@ module.exports = {
 
   getProfile: (req, res) => {
     res.render('profile', { css: 'profile' })
-  },
-
-  getOrders: async (req, res) => {
-    try {
-      let orders = await Order.findAll({
-        where: { user_id: req.user.id },
-        order: [['id', 'DESC']],
-        include: {
-          model: Product, as: 'products',
-          include: ['Gifts', 'Images']
-        }
-      })
-
-      orders.forEach(order => {
-        order.createdTime = order.createdAt.toJSON().split('T')[0]
-        order.amountFormat = order.amount.toLocaleString()
-        order.products.forEach(product => {
-          product.mainImg = product.Images.find(img => img.isMain).url
-          product.orderPrice = product.OrderItem.price.toLocaleString()
-          product.subPrice = product.OrderItem.quantity * product.price
-        })
-      })
-
-
-      res.render('orders', { orders, css: 'profile' })
-    } catch (err) {
-      console.error(err)
-      res.status(500).json({ status: 'serverError', message: err.toString() })
-    }
-
-
   },
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,5 +1,11 @@
 const crypto = require('crypto')
 
+function genDataChain(data) {
+  return Object.entries(data)
+    .map(([key, val]) => `${key}=${val}`)
+    .join('&')
+}
+
 module.exports = {
   /**
    * 製作分頁bar，link href
@@ -25,29 +31,23 @@ module.exports = {
     return queryString
   },
 
-  genDataChain(TradeInfo) {
-    return Object.entries(TradeInfo)
-      .map(([key, val]) => `${key}=${val}`)
-      .join('&')
-  },
-
-  aesEncrypt(TradeInfo, HashKey, HashIV) {
+  aesEncrypt(data, HashKey, HashIV) {
     const cipher = crypto.createCipheriv('aes256', HashKey, HashIV)
-    const encrypted = cipher.update(genDataChain(TradeInfo), 'utf8', 'hex')
+    const encrypted = cipher.update(genDataChain(data), 'utf8', 'hex')
     return encrypted + cipher.final('hex')
   },
 
-  aesDecrypt(encrypted, HashKey, HashIV) {
+  aesDecrypt(aesEncrypted, HashKey, HashIV) {
     const decipher = crypto.createDecipheriv('aes256', HashKey, HashIV)
     decipher.setAutoPadding(false)
-    const decrypted = decipher.update(encrypted, 'hex', 'utf8')
+    const decrypted = decipher.update(aesEncrypted, 'hex', 'utf8')
     const result = decrypted + decipher.final('utf8')
     return result.replace(/[\x00-\x20]+/g, "")
   },
 
-  shaHash(TradeInfo, HashKey, HashIV) {
+  shaHash(aesEncrypted, HashKey, HashIV) {
     const hash = crypto.createHash('sha256')
-    const data = `HashKey=${HashKey}&${TradeInfo}&HashIV=${HashIV}`
+    const data = `HashKey=${HashKey}&${aesEncrypted}&HashIV=${HashIV}`
     return hash.update(data).digest('hex').toUpperCase()
-  }
+  },
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,8 +1,10 @@
+const crypto = require('crypto')
+
 module.exports = {
   /**
    * 製作分頁bar，link href
    */
-  genQueryString: (query) => {
+  genQueryString(query) {
     let queryString = '?'
     if (query.q) {
       queryString += `q=${query.q}&`
@@ -21,5 +23,31 @@ module.exports = {
     }
 
     return queryString
+  },
+
+  genDataChain(TradeInfo) {
+    return Object.entries(TradeInfo)
+      .map(([key, val]) => `${key}=${val}`)
+      .join('&')
+  },
+
+  aesEncrypt(TradeInfo, HashKey, HashIV) {
+    const cipher = crypto.createCipheriv('aes256', HashKey, HashIV)
+    const encrypted = cipher.update(genDataChain(TradeInfo), 'utf8', 'hex')
+    return encrypted + cipher.final('hex')
+  },
+
+  aesDecrypt(encrypted, HashKey, HashIV) {
+    const decipher = crypto.createDecipheriv('aes256', HashKey, HashIV)
+    decipher.setAutoPadding(false)
+    const decrypted = decipher.update(encrypted, 'hex', 'utf8')
+    const result = decrypted + decipher.final('utf8')
+    return result.replace(/[\x00-\x20]+/g, "")
+  },
+
+  shaHash(TradeInfo, HashKey, HashIV) {
+    const hash = crypto.createHash('sha256')
+    const data = `HashKey=${HashKey}&${TradeInfo}&HashIV=${HashIV}`
+    return hash.update(data).digest('hex').toUpperCase()
   }
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -10,7 +10,7 @@ module.exports = {
     if (!req.isAuthenticated()) return res.redirect('/users/signin')
 
     // 確認用戶權限
-    if (!req.user.isAdmin) return res.redirect('/')
+    if (!req.user.isAdmin) return res.redirect('/users/profile')
     next()
   }
 }

--- a/migrations/20191228134628-create-order.js
+++ b/migrations/20191228134628-create-order.js
@@ -27,6 +27,9 @@ module.exports = {
       pay_status: {
         type: Sequelize.BOOLEAN
       },
+      order_no: {
+        type: Sequelize.STRING
+      },
       ship_status: {
         type: Sequelize.BOOLEAN
       },

--- a/migrations/20191228134628-create-order.js
+++ b/migrations/20191228134628-create-order.js
@@ -12,7 +12,8 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       sn: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        unique: true
       },
       amount: {
         type: Sequelize.INTEGER

--- a/migrations/20200109153129-create-payment.js
+++ b/migrations/20200109153129-create-payment.js
@@ -1,0 +1,44 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Payments', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      order_id: {
+        type: Sequelize.INTEGER
+      },
+      status: {
+        type: Sequelize.STRING
+      },
+      msg: {
+        type: Sequelize.STRING
+      },
+      trade_no: {
+        type: Sequelize.STRING
+      },
+      order_no: {
+        type: Sequelize.STRING
+      },
+      pay_time: {
+        type: Sequelize.DATE
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('NOW')
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('NOW')
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Payments');
+  }
+};

--- a/migrations/20200109153129-create-payment.js
+++ b/migrations/20200109153129-create-payment.js
@@ -12,6 +12,9 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       status: {
+        type: Sequelize.BOOLEAN
+      },
+      code: {
         type: Sequelize.STRING
       },
       msg: {

--- a/models/order.js
+++ b/models/order.js
@@ -7,6 +7,7 @@ module.exports = (sequelize, DataTypes) => {
     DeliveryId: DataTypes.INTEGER,
     payMethod: DataTypes.STRING,
     payStatus: DataTypes.BOOLEAN,
+    orderNo: DataTypes.STRING,
     shipStatus: DataTypes.BOOLEAN,
     receiver: DataTypes.STRING,
     address: DataTypes.STRING,

--- a/models/order.js
+++ b/models/order.js
@@ -14,6 +14,7 @@ module.exports = (sequelize, DataTypes) => {
     phone: DataTypes.STRING
   }, {});
   Order.associate = function (models) {
+    Order.hasMany(models.Payment)
     Order.belongsTo(models.Delivery)
     Order.belongsToMany(models.Product, {
       through: models.OrderItem,

--- a/models/payment.js
+++ b/models/payment.js
@@ -2,7 +2,8 @@
 module.exports = (sequelize, DataTypes) => {
   const Payment = sequelize.define('Payment', {
     OrderId: DataTypes.INTEGER,
-    status: DataTypes.STRING,
+    status: DataTypes.BOOLEAN,
+    code: DataTypes.STRING,
     msg: DataTypes.STRING,
     tradeNo: DataTypes.STRING,
     orderNo: DataTypes.STRING,

--- a/models/payment.js
+++ b/models/payment.js
@@ -1,0 +1,15 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const Payment = sequelize.define('Payment', {
+    OrderId: DataTypes.INTEGER,
+    status: DataTypes.STRING,
+    msg: DataTypes.STRING,
+    tradeNo: DataTypes.STRING,
+    orderNo: DataTypes.STRING,
+    payTime: DataTypes.DATE
+  }, {});
+  Payment.associate = function(models) {
+    Payment.belongsTo(models.Order)
+  };
+  return Payment;
+};

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -184,3 +184,7 @@ body {
 .userpage-link{
   color: #49443f;
 }
+
+.fa-gift{
+  color: #ff5402;
+}

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -117,3 +117,12 @@
 .order-info {
   font-size: 0.9rem;
 }
+
+/* button */
+.cart-btn {
+  display: inline-block;
+  background: #ff5400;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 10px;
+}

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -126,3 +126,23 @@
   font-weight: bold;
   border-radius: 10px;
 }
+
+.cell-image {
+  width: 10%!important;
+}
+
+.cell-name {
+  width: 40%!important;
+}
+
+.cell-quantity {
+  width: 15%!important;
+}
+
+.cell-price {
+  width: 20%!important;
+}
+
+.cell-subPrice {
+  width: 15%!important;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,16 +4,17 @@
  */
 const { getCartItem } = require('../middleware/cart.js')
 const { isAuth } = require('../middleware/auth.js')
+const { newebpayCb } = require('../controllers/orderCtrller.js')
 
 module.exports = app => {
   app.use('/admin', require('./admin/index.js'))
+  app.post('/newebpay/callback', newebpayCb)  // 金流API callback
   
   app.use('/', getCartItem)  // 請勿更動順序
   app.use('/products', require('./products.js'))
   app.use('/cart', require('./cart.js'))
   app.use('/orders', isAuth, require('./orders.js'))
   app.use('/users', require('./users.js'))
-  app.use('/admin', require('./admin/index.js'))
 
   app.get('/', (req, res) => res.render('home'))
   app.get('/search', require('../controllers/prodCtrller').getProducts)

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -2,6 +2,7 @@ const router = require('express').Router()
 const orderCtrller = require('../controllers/orderCtrller.js')
 
 // route base '/orders'
+router.get('/', orderCtrller.getOrders)
 router.get('/checkout', orderCtrller.setCheckout)      // 結帳入口
 
 router.get('/checkout_1', orderCtrller.getCheckout)    // 地址頁

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -16,4 +16,7 @@ router.post('/checkout_3', orderCtrller.checkout_3)    // post 付款
 router.get('/checkout_4', orderCtrller.getCheckout)    // 確認頁
 router.post('/', orderCtrller.postOrder)               // post 成立訂單
 
+router.get('/:id/payment', orderCtrller.getPayment)
+router.post('/newebpay/callback', orderCtrller.newebpayCb)
+
 module.exports = router

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -16,7 +16,6 @@ router.post('/checkout_3', orderCtrller.checkout_3)    // post 付款
 router.get('/checkout_4', orderCtrller.getCheckout)    // 確認頁
 router.post('/', orderCtrller.postOrder)               // post 成立訂單
 
-router.get('/:id/payment', orderCtrller.getPayment)
-router.post('/newebpay/callback', orderCtrller.newebpayCb)
+router.get('/:id/payment', orderCtrller.getPayment)    // 串金金流API
 
 module.exports = router

--- a/routes/users.js
+++ b/routes/users.js
@@ -11,6 +11,5 @@ router.post('/signin', userCtrller.signIn)
 router.get('/signout', userCtrller.signOut)
 
 router.get('/profile', isAuth, userCtrller.getProfile)
-router.get('/orders', isAuth, userCtrller.getOrders)
 
 module.exports = router

--- a/seeders/20191228142243-order-seeder.js
+++ b/seeders/20191228142243-order-seeder.js
@@ -15,7 +15,7 @@ module.exports = {
         amount: randomNum(2000, 30000),
         delivery_id: randomNum(1, 3),
         pay_method: faker.commerce.productMaterial(),
-        pay_status: randomNum(0, 1),
+        pay_status: 0,
         ship_status: randomNum(0, 1),
         receiver: faker.name.findName(),
         address: faker.address.zipCode() + ' ' + faker.address.city() + ' ' + faker.address.streetAddress() + faker.address.secondaryAddress(),

--- a/test/models/Order.spec.js
+++ b/test/models/Order.spec.js
@@ -10,6 +10,7 @@ const props = [
   'amount',
   'payMethod',
   'payStatus',
+  'orderNo',
   'shipStatus',
   'receiver',
   'address',

--- a/test/models/Payment.spec.js
+++ b/test/models/Payment.spec.js
@@ -7,6 +7,7 @@ const { propTest, assnTest, actionTest } = require('./lib/testTools.js')
 const props = [
   'OrderId',
   'status',
+  'code',
   'msg',
   'tradeNo',
   'orderNo',

--- a/test/models/Payment.spec.js
+++ b/test/models/Payment.spec.js
@@ -1,0 +1,22 @@
+process.env.NODE_ENV = 'test'
+
+const db = require('../../models')
+const PaymentModel = require('../../models/payment.js')
+const { propTest, assnTest, actionTest } = require('./lib/testTools.js')
+
+const props = [
+  'OrderId',
+  'status',
+  'msg',
+  'tradeNo',
+  'orderNo',
+  'payTime'
+]
+
+describe('# Payment Model', () => {
+  propTest(PaymentModel, 'Payment', props)
+  assnTest(PaymentModel, [
+    ['belongsTo', 'Order'],
+  ])
+  actionTest(db.Payment)
+})

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -26,7 +26,7 @@
                       <tr>
                         <td class="accordion-thead">{{this.sn}}</td>
                         <td class="accordion-thead">{{this.createdTime}}</td>
-                        <td class="accordion-thead">NTD {{this.amountFormat}}</td>
+                        <td class="accordion-thead">NTD {{addDot this.amount}}</td>
                       </tr>
                     </tbody>
                   </table>
@@ -94,7 +94,7 @@
                                 <div>
                                   <div class="ml-3">{{this.name}}</div>
                                   <div class="row ml-3">
-                                    <div>NTD {{this.orderPrice}}</div>
+                                    <div>NTD {{addDot this.OrderItem.price}}</div>
                                     <div class="ml-3">x {{this.OrderItem.quantity}}</div>
                                     <div class="ml-3">= {{addDot this.subPrice}}</div>
                                   </div>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -92,7 +92,11 @@
                                     style="height:50px">
                                 </a>
                                 <div>
-                                  <div class="ml-3">{{this.name}}</div>
+                                  <div class="ml-3">{{this.name}} 
+                                    {{#if this.Gifts}}
+                                    <label title="含特典"><i class="fas fa-gift"></i></label>
+                                    {{/if}}
+                                  </div>
                                   <div class="row ml-3">
                                     <div>NTD {{addDot this.OrderItem.price}}</div>
                                     <div class="ml-3">x {{this.OrderItem.quantity}}</div>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -56,9 +56,10 @@
                           <td class="accordion-title">付款狀態</td>
                           <td class="accordion-data">
                             {{#if this.payStatus}}
-                              已付款
+                              <span class="text-success font-weight-bold">已付款</span>
                             {{else}}
-                              未付款
+                              <span class="mr-3 text-danger font-weight-bold">未付款</span>
+                              <a href="/orders/{{this.id}}/payment" class="btn cart-btn">立即付款</a>
                             {{/if}}
                           </td>
                         </tr>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -73,6 +73,10 @@
                             {{/if}}
                           </td>
                         </tr>
+                        <tr>
+                          <td class="accordion-title">寄件方式</td>
+                          <td class="accordion-data">{{this.Delivery.method}} - NTD {{this.Delivery.price}} </td>
+                        </tr>
                       </tbody>
                     </table>
                     <hr>
@@ -92,12 +96,60 @@
                                   <div class="row ml-3">
                                     <div>NTD {{this.orderPrice}}</div>
                                     <div class="ml-3">x {{this.OrderItem.quantity}}</div>
+                                    <div class="ml-3">= {{addDot this.subPrice}}</div>
                                   </div>
                                 </div>
                               </div>
                             </td>
                           </tr>
                         {{/each}}
+                        <tr>
+                          <td class="accordion-title"></td>
+                          <td class="accordion-data">
+                            <div class="row col-12 mb-2">
+                              <div class="col-6 px-0">
+                                <hr class="mt-1">
+                                <div class="row ml-3 pr-0 d-flex justify-content-between">
+                                  <div class="pl-5 ml-5">小計 </div>
+                                  <div class="ml-2 pr-2">{{addDot this.sumPrice }}</div>
+                                </div>
+                              </div>
+                              <div class="col-6">
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td class="accordion-title"></td>
+                          <td class="accordion-data">
+                            <div class="row col-12 mb-2">
+                              <div class="col-6 px-0">
+                                <div class="row ml-3 pr-0 d-flex justify-content-between">
+                                  <div class="pl-5 ml-5">運費 </div>
+                                  <div class="ml-2 pr-2">{{addDot this.Delivery.price }}</div>
+                                </div>
+                              </div>
+                              <div class="col-6">
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td class="accordion-title"></td>
+                          <td class="accordion-data">
+                            <div class="row col-12 mb-2">
+                              <div class="col-6 px-0">
+                                <hr class="mt-1">
+                                <div class="row ml-3 pr-0 d-flex justify-content-between">
+                                  <div class="pl-5 ml-5 font-weight-bold">總金額 </div>
+                                  <div class="ml-2 pr-2 font-weight-bold">{{addDot this.amount }}</div>
+                                </div>
+                              </div>
+                              <div class="col-6">
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
                       </tbody>
                     </table>
                   </div>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -136,7 +136,7 @@
                 <a href="#" class="text-decoration-none profile-href side-list-text">密碼變更</a>
               </li>
               <li>
-                <a href="/users/orders" class="text-decoration-none font-weight-bold text-pick side-list-text">訂購紀錄</a>
+                <a href="/orders" class="text-decoration-none font-weight-bold text-pick side-list-text">訂購紀錄</a>
               </li>
             </ul>
           </div>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -75,83 +75,73 @@
                         </tr>
                         <tr>
                           <td class="accordion-title">寄件方式</td>
-                          <td class="accordion-data">{{this.Delivery.method}} - NTD {{this.Delivery.price}} </td>
+                          <td class="accordion-data">{{this.Delivery.method}}</td>
                         </tr>
                       </tbody>
                     </table>
                     <hr>
-                    <table class="order-info">
+                    <table class="mx-auto order-info">
                       <tbody>
                         {{#each this.products}}
-                          <tr>
-                            <td class="accordion-title"></td>
-                            <td class="accordion-data">
-                              <div class="row col-12 mb-2">
-                                <a href="/products/{{this.id}}" class="product-img">
-                                  <img src="{{this.mainImg}}" class="rounded mx-auto d-block" alt="productImage"
-                                    style="height:50px">
-                                </a>
-                                <div>
-                                  <div class="ml-3">{{this.name}} 
-                                    {{#if this.Gifts}}
+                          <tr class="mb-2">
+                            <td class="cell-img">
+                              <a href="/products/{{this.id}}" class="product-img">
+                                <img src="{{this.mainImg}}" class="rounded mx-2 float-right my-1" alt="productImage"
+                                  style="height:50px">
+                              </a>
+                            </td>
+                            <td class="cell-name">
+                              <a href="/products/{{this.id}}" class="text-body text-decoration-none">
+                                <div class="text-left ml-2">
+                                  {{this.name}}
+                                  {{#if this.Gifts}}
                                     <label title="含特典"><i class="fas fa-gift"></i></label>
-                                    {{/if}}
-                                  </div>
-                                  <div class="row ml-3">
-                                    <div>NTD {{addDot this.OrderItem.price}}</div>
-                                    <div class="ml-3">x {{this.OrderItem.quantity}}</div>
-                                    <div class="ml-3">= {{addDot this.subPrice}}</div>
-                                  </div>
+                                  {{/if}}
                                 </div>
-                              </div>
+                              </a>
+                            </td>
+                            <td class="cell-quantity">
+                              <div class="text-right">x {{this.OrderItem.quantity}}</div>
+                            </td>
+                            <td class="cell-price">
+                              <div class="text-right">NTD {{addDot this.OrderItem.price}} =</div>
+                            </td>
+                            <td class="cell-subPrice">
+                              <div class="text-right">{{addDot this.subPrice}}</div>
                             </td>
                           </tr>
                         {{/each}}
                         <tr>
-                          <td class="accordion-title"></td>
-                          <td class="accordion-data">
-                            <div class="row col-12 mb-2">
-                              <div class="col-6 px-0">
-                                <hr class="mt-1">
-                                <div class="row ml-3 pr-0 d-flex justify-content-between">
-                                  <div class="pl-5 ml-5">小計 </div>
-                                  <div class="ml-2 pr-2">{{addDot this.sumPrice }}</div>
-                                </div>
-                              </div>
-                              <div class="col-6">
-                              </div>
-                            </div>
+                          <td></td>
+                          <td></td>
+                          <td></td>
+                          <td class="cell-price">
+                            <div class="text-right">小計</div>
+                          </td>
+                          <td class="cell-subPrice">
+                            <div class="text-right">{{addDot this.sumPrice}}</div>
                           </td>
                         </tr>
                         <tr>
-                          <td class="accordion-title"></td>
-                          <td class="accordion-data">
-                            <div class="row col-12 mb-2">
-                              <div class="col-6 px-0">
-                                <div class="row ml-3 pr-0 d-flex justify-content-between">
-                                  <div class="pl-5 ml-5">運費 </div>
-                                  <div class="ml-2 pr-2">{{addDot this.Delivery.price }}</div>
-                                </div>
-                              </div>
-                              <div class="col-6">
-                              </div>
-                            </div>
+                          <td></td>
+                          <td></td>
+                          <td></td>
+                          <td class="cell-price">
+                            <div class="text-right">運費</div>
+                          </td>
+                          <td class="cell-subPrice">
+                            <div class="text-right">{{addDot this.Delivery.price}}</div>
                           </td>
                         </tr>
                         <tr>
-                          <td class="accordion-title"></td>
-                          <td class="accordion-data">
-                            <div class="row col-12 mb-2">
-                              <div class="col-6 px-0">
-                                <hr class="mt-1">
-                                <div class="row ml-3 pr-0 d-flex justify-content-between">
-                                  <div class="pl-5 ml-5 font-weight-bold">總金額 </div>
-                                  <div class="ml-2 pr-2 font-weight-bold">{{addDot this.amount }}</div>
-                                </div>
-                              </div>
-                              <div class="col-6">
-                              </div>
-                            </div>
+                          <td></td>
+                          <td></td>
+                          <td></td>
+                          <td class="cell-price">
+                            <div class="text-right">總金額</div>
+                          </td>
+                          <td class="cell-subPrice">
+                            <div class="text-right">{{addDot this.amount}}</div>
                           </td>
                         </tr>
                       </tbody>

--- a/views/payment.hbs
+++ b/views/payment.hbs
@@ -1,0 +1,2 @@
+<h3>訂單編號: {{order.sn}}</h3>
+<p>金額: {{order.amount}}</p>

--- a/views/payment.hbs
+++ b/views/payment.hbs
@@ -1,2 +1,14 @@
 <h3>訂單編號: {{order.sn}}</h3>
 <p>金額: {{order.amount}}</p>
+
+<form name='newebpay' action='{{tradeInfo.PayGateWay}}' method="POST">
+  MerchantID:
+  <input type="text" name="MerchantID" value="{{tradeInfo.MerchantID}}"><br>
+  TradeInfo:
+  <input type="text" name="TradeInfo" value="{{tradeInfo.TradeInfo}}"><br>
+  TradeSha:
+  <input type="text" name="TradeSha" value="{{tradeInfo.TradeSha}}"><br>
+  Version:
+  <input type="text" name="Version" value="{{tradeInfo.Version}}"><br>
+  <button type="submit" class="btn btn-primary">Payment</button>
+</form>

--- a/views/payment.hbs
+++ b/views/payment.hbs
@@ -1,14 +1,13 @@
-<h3>訂單編號: {{order.sn}}</h3>
-<p>金額: {{order.amount}}</p>
+<h2 style="text-align: center;">跳轉中...</h2>
 
-<form name='newebpay' action='{{tradeInfo.PayGateWay}}' method="POST">
-  MerchantID:
-  <input type="text" name="MerchantID" value="{{tradeInfo.MerchantID}}"><br>
-  TradeInfo:
-  <input type="text" name="TradeInfo" value="{{tradeInfo.TradeInfo}}"><br>
-  TradeSha:
-  <input type="text" name="TradeSha" value="{{tradeInfo.TradeSha}}"><br>
-  Version:
-  <input type="text" name="Version" value="{{tradeInfo.Version}}"><br>
-  <button type="submit" class="btn btn-primary">Payment</button>
+<form id="newebpay" name="newebpay" action='{{tradeInfo.PayGateWay}}' method="POST" hidden>
+  <input type="text" name="MerchantID" value="{{tradeInfo.MerchantID}}">
+  <input type="text" name="TradeInfo" value="{{tradeInfo.TradeInfo}}">
+  <input type="text" name="TradeSha" value="{{tradeInfo.TradeSha}}">
+  <input type="text" name="Version" value="{{tradeInfo.Version}}">
 </form>
+
+<script>
+  const form = document.querySelector('#newebpay')
+  form.submit()
+</script>

--- a/views/profile.hbs
+++ b/views/profile.hbs
@@ -36,7 +36,7 @@
               </div>
               <div>
                 <ul class="item-list">
-                  <li><a href="/users/orders" class="text-decoration-none profile-href ">訂購紀錄</a></li>
+                  <li><a href="/orders" class="text-decoration-none profile-href ">訂購紀錄</a></li>
                 </ul>
               </div>
             </div>
@@ -64,7 +64,7 @@
                 <a href="#" class="text-decoration-none profile-href side-list-text">密碼變更</a>
               </li>
               <li>
-                <a href="/users/orders" class="text-decoration-none profile-href side-list-text">訂購紀錄</a>
+                <a href="/orders" class="text-decoration-none profile-href side-list-text">訂購紀錄</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION

<img width="852" alt="螢幕快照 2020-01-11 上午12 23 45" src="https://user-images.githubusercontent.com/49901777/72168724-a91f3980-3408-11ea-9f33-f955ad87d599.png">

## 優化內容
- 追加寄件方式欄位
- 修改下方訂單商品總覽頁面排版
- 商品有特典時顯示特典icon
- 清單上會附上各商品下定時金額、數量與相乘的價錢
- 總金額有加上運費計算
- 金額統一採用addDot格式化

## 手動確認
- 訂單商品一覽的價錢與數量是否與資料庫中相同
- 含有特點之商品可以正確顯示icon
- 商品圖片與名稱可以連結到該product頁面

## 尚未製作
- 重新發送確認信 (待此PR merge後)
- 取消訂單
- 編輯收件地址
- 顯示帳單地址
- 顯示支付期限