### PR TITLE
【加入】後台商品詳細頁 Tag

### DIFF
--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -9,9 +9,8 @@ module.exports = {
     try {
       const products = await Product.findAll({
         order: [['id', 'DESC']],
-        include: [Category, Series, Image]
+        include: [Category, Series, Image, 'tags']
       })
-
 
       //判斷日期用
       const today = new Date()

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -127,6 +127,11 @@
                         {{/if}}
                         <p>分類： {{this.Category.name}}</p>
                         <p>作品： {{this.Series.name}}</p>
+                        <p>Tag：
+                          {{#each this.tags}}
+                            #{{this.name}}
+                          {{/each}}
+                        </p>
                       </div>
                     </div>
                   </div>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -109,30 +109,34 @@
                   <h4>#{{this.id}} {{this.name}}</h4>
                   <hr>
                   <div class="row">
-                    <div class="col-6 ">
+                    <div class="col-12">
                       <p>商品標語： {{this.slogan}}</p>
                       <p>商品內文：{{this.description}}</p>
                     </div>
                     <div class="col-6">
                       <div>
-                        <p>售價： {{this.price}}</p>
-                        <p>庫存： {{this.inventory}}</p>
-                        <p>規格： {{this.spec}}</p>
-                        <p>版權： {{this.copyright}}</p>
-                        <p>廠商： {{this.maker}}</p>
-                        {{#if this.status}}
-                          <p>狀態： 上架中</p>
-                        {{else}}
-                          <p>狀態： 未上架</p>
-                        {{/if}}
                         <p>分類： {{this.Category.name}}</p>
                         <p>作品： {{this.Series.name}}</p>
                         <p>Tag：
                           {{#each this.tags}}
-                            #{{this.name}}
+                          #{{this.name}}
                           {{/each}}
                         </p>
                       </div>
+                    </div>
+                    <div class="col-6 ">
+                      {{#if this.status}}
+                      <p>狀態： 上架中</p>
+                      {{else}}
+                      <p>狀態： 未上架</p>
+                      {{/if}}
+                      <p>售價： {{this.price}}</p>
+                      <p>庫存： {{this.inventory}}</p>
+                    </div>
+                    <div class="col-12">
+                      <p>廠商： {{this.maker}}</p>
+                      <p>版權： {{this.copyright}}</p>
+                      <p>規格： {{this.spec}}</p>
                     </div>
                   </div>
                   <hr>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -114,29 +114,26 @@
                       <p>商品內文：{{this.description}}</p>
                     </div>
                     <div class="col-6">
-                      <div>
-                        <p>分類： {{this.Category.name}}</p>
-                        <p>作品： {{this.Series.name}}</p>
-                        <p>Tag：
-                          {{#each this.tags}}
-                          #{{this.name}}
-                          {{/each}}
-                        </p>
-                      </div>
-                    </div>
-                    <div class="col-6 ">
                       {{#if this.status}}
-                      <p>狀態： 上架中</p>
+                        <p>狀態： 上架中</p>
                       {{else}}
-                      <p>狀態： 未上架</p>
+                        <p>狀態： 未上架</p>
                       {{/if}}
                       <p>售價： {{this.price}}</p>
                       <p>庫存： {{this.inventory}}</p>
-                    </div>
-                    <div class="col-12">
                       <p>廠商： {{this.maker}}</p>
                       <p>版權： {{this.copyright}}</p>
                       <p>規格： {{this.spec}}</p>
+                    </div>
+                    <div class="col-6 ">
+                      <p>分類： {{this.Category.name}}</p>
+                      <p>作品別： {{this.Series.name}}</p>
+                      <p>
+                        <span>標籤：</span>
+                        {{#each this.tags}}
+                          <span>#{{this.name}}</span>
+                        {{/each}}
+                      </p>
                     </div>
                   </div>
                   <hr>


### PR DESCRIPTION
## 內容
- 後台商品詳細頁新增 Tag 欄
- 調整商品詳細頁 UI

因商品內文實際上內容很多，所以目前調整為以下樣式~

<img src="https://user-images.githubusercontent.com/50958992/72198271-4492c780-3466-11ea-8dbc-e639d7559c11.png" width=500px>

