### PR TITLE
【加入】後台交易紀錄頁面及搜尋功能

### DIFF
--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -15,17 +15,19 @@ module.exports = {
         where.order_id = inputSn
       }
 
-      const payment = await Payment.findOne({ where })
-      if (!payment) {
+      const payments = await Payment.findAll({ where })
+      if (!payments) {
         req.flash('error', '找不到此訂單交易紀錄')
         return res.redirect('/admin/payments')
       }
 
       // SN、時間格式
-      payment.SN = ("000000000" + inputSn).slice(-10)
-      payment.payDate = moment(payment.payTime).format('YYYY/MM/DD HH:mm')
+      payments.forEach(payment => {
+        payment.SN = ("000000000" + inputSn).slice(-10)
+        payment.payDate = moment(payment.payTime).format('YYYY/MM/DD HH:mm')
+      });
 
-      res.render('admin/payments', { payment, inputSn })
+      res.render('admin/payments', { payments, inputSn })
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -3,7 +3,7 @@ const { Payment } = db
 
 
 module.exports = {
-  getpayments: async (req, res) => {
+  getPayments: async (req, res) => {
     try {
       
       res.render('admin/payments')

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -23,7 +23,7 @@ module.exports = {
 
       // SN、時間格式
       payment.SN = ("000000000" + inputSn).slice(-10)
-      payment.payDate = moment(payment.pay_time).format('YYYY/MM/DD HH:mm')
+      payment.payDate = moment(payment.payTime).format('YYYY/MM/DD HH:mm')
 
       res.render('admin/payments', { payment, inputSn })
 

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -7,7 +7,7 @@ moment.locale('zh-tw')
 module.exports = {
   getPayments: async (req, res) => {
     try {
-      const inputSn = +req.query.sn      
+      let inputSn = +req.query.sn      
       let where = {}
       if (!inputSn) {
         return res.render('admin/payments') // 首次進入不需 Query
@@ -26,8 +26,8 @@ module.exports = {
         payment.SN = ("000000000" + inputSn).slice(-10)
         payment.payDate = moment(payment.payTime).format('YYYY/MM/DD HH:mm')
       });
-
-      res.render('admin/payments', { payments, inputSn })
+      showSn = ("000000000" + inputSn).slice(-10)
+      res.render('admin/payments', { payments, showSn })
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -16,7 +16,7 @@ module.exports = {
       const payment = await Payment.findOne({ where })
       if (!payment) {
         req.flash('error', '找不到此訂單交易紀錄')
-        res.redirect('back')
+        return res.redirect('/admin/payments')
       }
 
       // SN格式

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -7,15 +7,12 @@ moment.locale('zh-tw')
 module.exports = {
   getPayments: async (req, res) => {
     try {
-      let inputSn = +req.query.sn      
-      let where = {}
-      if (!inputSn) {
-        return res.render('admin/payments') // 首次進入不需 Query
-      } else {
-        where.order_id = inputSn
-      }
+      const inputSn = +req.query.sn
 
-      const payments = await Payment.findAll({ where })
+      // 首次進入不需 Query
+      if (!inputSn) return res.render('admin/payments')
+
+      const payments = await Payment.findAll({ where: { OrderId: inputSn } })
       const showSn = req.query.sn
       
       // 確認是否有此筆訂單

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -16,9 +16,12 @@ module.exports = {
       }
 
       const payments = await Payment.findAll({ where })
-      if (!payments) {
-        req.flash('error', '找不到此訂單交易紀錄')
-        return res.redirect('/admin/payments')
+      const showSn = req.query.sn
+      
+      // 確認是否有此筆訂單
+      if (payments.length === 0) {
+        const error = '找不到此訂單交易紀錄'
+        return res.render('admin/payments', { error, showSn })
       }
 
       // SN、時間格式
@@ -26,7 +29,7 @@ module.exports = {
         payment.SN = ("000000000" + inputSn).slice(-10)
         payment.payDate = moment(payment.payTime).format('YYYY/MM/DD HH:mm')
       });
-      showSn = ("000000000" + inputSn).slice(-10)
+
       res.render('admin/payments', { payments, showSn })
 
     } catch (err) {

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -1,0 +1,16 @@
+const db = require('../../models')
+const { Payment } = db
+
+
+module.exports = {
+  getpayments: async (req, res) => {
+    try {
+      
+      res.render('admin/payments')
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  },
+}

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -1,6 +1,8 @@
 const db = require('../../models')
 const Payment = db.Payment
 
+const moment = require('moment')
+moment.locale('zh-tw')
 
 module.exports = {
   getPayments: async (req, res) => {
@@ -19,8 +21,9 @@ module.exports = {
         return res.redirect('/admin/payments')
       }
 
-      // SN格式
+      // SN、時間格式
       payment.SN = ("000000000" + inputSn).slice(-10)
+      payment.payDate = moment(payment.pay_time).format('YYYY/MM/DD HH:mm')
 
       res.render('admin/payments', { payment, inputSn })
 

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -1,12 +1,27 @@
 const db = require('../../models')
-const { Payment } = db
+const Payment = db.Payment
 
 
 module.exports = {
   getPayments: async (req, res) => {
     try {
-      
-      res.render('admin/payments')
+      const inputSn = +req.query.sn      
+      let where = {}
+      if (!inputSn) {
+        return res.render('admin/payments') // 首次進入不需 Query
+      } else {
+        where.order_id = inputSn
+      }
+
+      const payment = await Payment.findOne({ where })
+      if (!payment) {
+        res.redirect('back')
+      }
+
+      // SN格式
+      payment.SN = ("000000000" + inputSn).slice(-10)
+
+      res.render('admin/payments', { payment, inputSn })
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -15,6 +15,7 @@ module.exports = {
 
       const payment = await Payment.findOne({ where })
       if (!payment) {
+        req.flash('error', '找不到此訂單交易紀錄')
         res.redirect('back')
       }
 

--- a/routes/admin/index.js
+++ b/routes/admin/index.js
@@ -15,6 +15,7 @@ router.use('/products', require('./products.js'))
 router.use('/users', require('./users.js'))
 router.use('/orders', require('./orders.js'))
 router.use('/tags', require('./tags.js'))
+router.use('/payments', require('./payments.js'))
 
 
 module.exports = router

--- a/routes/admin/payments.js
+++ b/routes/admin/payments.js
@@ -2,6 +2,6 @@ const router = require('express').Router()
 const paymentCtrller = require('../../controllers/admin/paymentCtrller')
 
 // route base '/admin/payments'
-router.get('/', paymentCtrller.getpayments)
+router.get('/', paymentCtrller.getPayments)
 
 module.exports = router

--- a/routes/admin/payments.js
+++ b/routes/admin/payments.js
@@ -1,0 +1,7 @@
+const router = require('express').Router()
+const paymentCtrller = require('../../controllers/admin/paymentCtrller')
+
+// route base '/admin/payments'
+router.get('/', paymentCtrller.getpayments)
+
+module.exports = router

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -3,7 +3,7 @@
     <div class="row my-3">
       <form action="/admin/payments" method="GET" class="col-md-3 mb-3">
         <div class="input-group mb-3">
-          <input type="text" class="form-control" name="sn" placeholder="請輸入訂單編號(SN)" value="{{inputSn}}">
+          <input type="text" class="form-control" name="sn" placeholder="請輸入訂單編號(SN)" value="{{showSn}}">
           <div class="input-group-append">
             <button class="btn btn-secondary" type="submit" id="button-addon2">訂單查詢</button>
           </div>

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -1,0 +1,5 @@
+<main class="container">
+  <div class="card-body pt-4">
+    <p>payments</p>
+  </div>
+</main>

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -9,6 +9,9 @@
           </div>
         </div>
       </form>
+      <div class="col-md-6">
+        {{> alert}}
+      </div>
     </div>
 
     <table data-toggle="table" data-pagination="true" id="table">

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -1,5 +1,36 @@
 <main class="container">
   <div class="card-body pt-4">
-    <p>payments</p>
+    <div class="row my-3">
+      <form action="/admin/payments" method="POST" class="col-md-6">
+        <div class="input-group mb-3 mx-auto ">
+          <input type="text" class="form-control" name="sn" placeholder="請輸入訂單編號(SN)">
+          <div class="input-group-append">
+            <button class="btn btn-secondary" type="submit" id="button-addon2">訂單查詢</button>
+          </div>
+        </div>
+      </form>
+    </div>
+
+    <table data-toggle="table" data-pagination="true" id="table">
+      <thead>
+        <tr>
+          <th data-valign="middle" class="text-center" data-sortable="true">#</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">SN</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">付款狀態</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">付款時間</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">藍新交易序號</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">識別碼</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{{payment.id}}</td>
+          <td>{{payment.sn}}</td>
+          <td>{{payment.createdTime}}</td>
+          <td>{{payment.amount}}</td>
+          <td>{{payment.payMethod}}</td>
+        </tr>  
+      </tbody>
+    </table>
   </div>
 </main>

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -26,14 +26,16 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td>{{payment.id}}</td>
-          <td>{{payment.SN}}</td>
-          <td>{{payment.msg}}</td>
-          <td>{{payment.tradeNo}}</td>
-          <td>{{payment.orderNo}}</td>
-          <td>{{payment.payDate}}</td>
-        </tr>  
+        {{#each payments}}
+          <tr>
+            <td>{{this.id}}</td>
+            <td>{{this.SN}}</td>
+            <td>{{this.msg}}</td>
+            <td>{{this.tradeNo}}</td>
+            <td>{{this.orderNo}}</td>
+            <td>{{this.payDate}}</td>
+          </tr>
+        {{/each}}  
       </tbody>
     </table>
   </div>

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -22,6 +22,7 @@
           <th data-valign="middle" class="text-center" data-sortable="true">#</th>
           <th data-valign="middle" class="text-center" data-sortable="true">SN</th>
           <th data-valign="middle" class="text-center" data-sortable="true">付款狀態</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">狀態代碼</th>
           <th data-valign="middle" class="text-center" data-sortable="true">藍新交易序號</th>
           <th data-valign="middle" class="text-center" data-sortable="true">商店交易序號</th>
           <th data-valign="middle" class="text-center" data-sortable="true">付款時間</th>
@@ -33,6 +34,7 @@
             <td>{{this.id}}</td>
             <td>{{this.SN}}</td>
             <td>{{this.msg}}</td>
+            <td>{{this.code}}</td>
             <td>{{this.tradeNo}}</td>
             <td>{{this.orderNo}}</td>
             <td>{{this.payDate}}</td>

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -32,7 +32,7 @@
           <td>{{payment.msg}}</td>
           <td>{{payment.tradeNo}}</td>
           <td>{{payment.orderNo}}</td>
-          <td>{{payment.payTime}}</td>
+          <td>{{payment.payDate}}</td>
         </tr>  
       </tbody>
     </table>

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -1,9 +1,9 @@
 <main class="container">
   <div class="card-body pt-4">
     <div class="row my-3">
-      <form action="/admin/payments" method="POST" class="col-md-6">
+      <form action="/admin/payments" method="GET" class="col-md-6">
         <div class="input-group mb-3 mx-auto ">
-          <input type="text" class="form-control" name="sn" placeholder="請輸入訂單編號(SN)">
+          <input type="text" class="form-control" name="sn" placeholder="請輸入訂單編號(SN)" value="{{inputSn}}">
           <div class="input-group-append">
             <button class="btn btn-secondary" type="submit" id="button-addon2">訂單查詢</button>
           </div>
@@ -17,18 +17,19 @@
           <th data-valign="middle" class="text-center" data-sortable="true">#</th>
           <th data-valign="middle" class="text-center" data-sortable="true">SN</th>
           <th data-valign="middle" class="text-center" data-sortable="true">付款狀態</th>
-          <th data-valign="middle" class="text-center" data-sortable="true">付款時間</th>
           <th data-valign="middle" class="text-center" data-sortable="true">藍新交易序號</th>
           <th data-valign="middle" class="text-center" data-sortable="true">識別碼</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">付款時間</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>{{payment.id}}</td>
-          <td>{{payment.sn}}</td>
-          <td>{{payment.createdTime}}</td>
-          <td>{{payment.amount}}</td>
-          <td>{{payment.payMethod}}</td>
+          <td>{{payment.SN}}</td>
+          <td>{{payment.msg}}</td>
+          <td>{{payment.tradeNo}}</td>
+          <td>{{payment.orderNo}}</td>
+          <td>{{payment.payTime}}</td>
         </tr>  
       </tbody>
     </table>

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -10,7 +10,9 @@
         </div>
       </form>
       <div class="col-md-9">
-        {{> alert}}
+        {{#if error}}
+          {{> alert}}
+        {{/if}}
       </div>
     </div>
 

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -23,7 +23,7 @@
           <th data-valign="middle" class="text-center" data-sortable="true">SN</th>
           <th data-valign="middle" class="text-center" data-sortable="true">付款狀態</th>
           <th data-valign="middle" class="text-center" data-sortable="true">藍新交易序號</th>
-          <th data-valign="middle" class="text-center" data-sortable="true">識別碼</th>
+          <th data-valign="middle" class="text-center" data-sortable="true">商店交易序號</th>
           <th data-valign="middle" class="text-center" data-sortable="true">付款時間</th>
         </tr>
       </thead>

--- a/views/admin/payments.hbs
+++ b/views/admin/payments.hbs
@@ -1,15 +1,15 @@
 <main class="container">
   <div class="card-body pt-4">
     <div class="row my-3">
-      <form action="/admin/payments" method="GET" class="col-md-6">
-        <div class="input-group mb-3 mx-auto ">
+      <form action="/admin/payments" method="GET" class="col-md-3 mb-3">
+        <div class="input-group mb-3">
           <input type="text" class="form-control" name="sn" placeholder="請輸入訂單編號(SN)" value="{{inputSn}}">
           <div class="input-group-append">
             <button class="btn btn-secondary" type="submit" id="button-addon2">訂單查詢</button>
           </div>
         </div>
       </form>
-      <div class="col-md-6">
+      <div class="col-md-9">
         {{> alert}}
       </div>
     </div>

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -41,6 +41,9 @@
         <li class="nav-item">
           <a class="nav-link {{#ifEqual path '/tags'}}active{{/ifEqual}}" href="/admin/tags">標籤</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link {{#ifEqual path '/payments'}}active{{/ifEqual}}" href="/admin/payments">交易紀錄</a>
+        </li>
         <br>
       </ul>
       <a class="btn btn-outline-secondary ml-3" href="/users/signout">登出</a>


### PR DESCRIPTION
![1578813928911](https://user-images.githubusercontent.com/50958992/72215604-cf032600-354f-11ea-99f5-00d691b53a6d.jpg)

## 內容
- 後台交易紀錄頁 UI
- 搜尋交易紀錄功能
- 因欄位較少，所以把欄位增減功能拿掉了
- 後台 navbar 加入 `交易紀錄` 選項

## 確認內容
- 管理者可以輸入 SN 或是 order_id 來搜尋訂單紀錄
- 有紀錄時可以看到此筆訂單交易紀錄
- 搜尋不到時，將會顯示 alert
- 保留 alert 的位置，使下面表單不會隨著 alert 的顯示移動
- 時間格式需顯示日期 + 時間 (不確定需不需要到秒)

## 其他
- 原本想讓搜尋不到紀錄時，跳回去還能顯示搜尋的SN，有使用 req.flash，但一直沒成功


![2](https://user-images.githubusercontent.com/50958992/72215574-3f5d7780-354f-11ea-95bb-ceee015f2f28.png)


