### PR TITLE
【加入】後台特典CRUD

### DIFF
--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -9,7 +9,13 @@ module.exports = {
       const gifts = await Gift.findAll({
         order: [['id', 'ASC']]
       })
-      console.log(gifts)
+      
+      gifts.forEach(gift => {
+        if (!gift.image) {
+          gift.image = 'https://citainsp.org/wp-content/uploads/2016/01/default.jpg'
+        }
+      });
+
       res.render('admin/gifts', { gifts })
     } catch (err) {
       console.error(err)
@@ -17,29 +23,29 @@ module.exports = {
     }
   },
 
-  // postTags: async (req, res) => {
-  //   try {
-  //     const input = { ...req.body }
-  //     if (input.name.trim() === '') {
+  postGifts: async (req, res) => {
+    try {
+      const input = { ...req.body }
+      if (input.name.trim() === '') {
 
-  //       req.flash('error', '標籤名稱不能為空白')
-  //       res.redirect('/admin/tags')
+        req.flash('error', '特典名稱不能為空白')
+        res.redirect('/admin/gifts')
 
-  //     } else {
+      } else {
 
-  //       const maxId = await Tag.max('id')
-  //       await Tag.create({ id: maxId + 1, ...input })
+        const maxId = await Gift.max('id')
+        await Gift.create({ id: maxId + 1, ...input })
 
-  //       req.flash('success', '新增成功！')
-  //       res.redirect('/admin/tags')
+        req.flash('success', '新增成功！')
+        res.redirect('/admin/gifts')
 
-  //     }
+      }
 
-  //   } catch (err) {
-  //     console.error(err)
-  //     res.status(500).json(err.toString())
-  //   }
-  // },
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
 
   // putTag: async (req, res) => {
   //   try {
@@ -47,16 +53,16 @@ module.exports = {
 
   //     if (input.name.trim() === '') {
 
-  //       req.flash('error', '標籤名稱不能為空白')
+  //       req.flash('error', '特典名稱不能為空白')
   //       res.redirect('back')
 
   //     } else {
 
-  //       const id = +req.params.tagsid
+  //       const id = +req.params.giftsid
   //       await Tag.update(input, { where: { id } })
 
   //       req.flash('success', '更新成功！')
-  //       res.redirect('/admin/tags')
+  //       res.redirect('/admin/gifts')
 
   //     }
 
@@ -69,11 +75,11 @@ module.exports = {
   // deleteTag: async (req, res) => {
   //   try {
 
-  //     const id = +req.params.tagsid
+  //     const id = +req.params.giftsid
   //     await Tag.destroy({ where: { id } })
 
   //     req.flash('success', '刪除成功！')
-  //     res.redirect('/admin/tags')
+  //     res.redirect('/admin/gifts')
 
   //   } catch (err) {
   //     console.error(err)

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -72,19 +72,19 @@ module.exports = {
     }
   },
 
-  // deleteTag: async (req, res) => {
-  //   try {
+  deleteGift: async (req, res) => {
+    try {
 
-  //     const id = +req.params.giftsid
-  //     await Tag.destroy({ where: { id } })
+      const id = +req.params.giftsid
+      await Gift.destroy({ where: { id } })
 
-  //     req.flash('success', '刪除成功！')
-  //     res.redirect('/admin/gifts')
+      req.flash('success', '刪除成功！')
+      res.redirect('/admin/gifts')
 
-  //   } catch (err) {
-  //     console.error(err)
-  //     res.status(500).json(err.toString())
-  //   }
-  // },
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
 
 }

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -60,13 +60,18 @@ module.exports = {
   putGift: async (req, res) => {
     try {
       const input = { ...req.body }
-
       if (input.name.trim() === '') {
 
         req.flash('error', '特典名稱不能為空白')
         res.redirect('back')
 
       } else {
+
+        const { file } = req
+      console.log(req.body)
+        if (file) {
+          input.image = (await imgur.uploadFile(file.path)).data.link
+        }
 
         const id = +req.params.giftsid
         await Gift.update(input, { where: { id } })

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -28,7 +28,6 @@ module.exports = {
   postGift: async (req, res) => {
     try {
       const input = { ...req.body }
-      console.log(req)
       if (input.name.trim() === '') {
 
         req.flash('error', '特典名稱不能為空白')
@@ -68,7 +67,7 @@ module.exports = {
       } else {
 
         const { file } = req
-      console.log(req.body)
+      
         if (file) {
           input.image = (await imgur.uploadFile(file.path)).data.link
         }

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -1,5 +1,7 @@
 const db = require('../../models')
 const { Gift } = db
+const imgur = require('imgur')
+const IMGUR_CLIENT_ID = process.env.IMGUR_CLIENT_ID
 
 
 module.exports = {
@@ -26,6 +28,7 @@ module.exports = {
   postGift: async (req, res) => {
     try {
       const input = { ...req.body }
+      console.log(req)
       if (input.name.trim() === '') {
 
         req.flash('error', '特典名稱不能為空白')
@@ -33,11 +36,18 @@ module.exports = {
 
       } else {
 
-        const maxId = await Gift.max('id')
-        await Gift.create({ id: maxId + 1, ...input })
 
-        req.flash('success', '新增成功！')
-        res.redirect('/admin/gifts')
+      //寫入Image
+      const { file } = req
+      if (file) {
+        input.image = (await imgur.uploadFile(file.path)).data.link
+      }
+
+      const maxId = await Gift.max('id')
+      await Gift.create({ id: maxId + 1, ...input })
+
+      req.flash('success', '新增成功！')
+      res.redirect('/admin/gifts')
 
       }
 

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -1,8 +1,9 @@
 const db = require('../../models')
 const { Gift } = db
+
 const imgur = require('imgur')
 const IMGUR_CLIENT_ID = process.env.IMGUR_CLIENT_ID
-
+imgur.setClientId(IMGUR_CLIENT_ID)
 
 module.exports = {
   getGifts: async (req, res) => {

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -23,7 +23,7 @@ module.exports = {
     }
   },
 
-  postGifts: async (req, res) => {
+  postGift: async (req, res) => {
     try {
       const input = { ...req.body }
       if (input.name.trim() === '') {
@@ -47,30 +47,30 @@ module.exports = {
     }
   },
 
-  // putTag: async (req, res) => {
-  //   try {
-  //     const input = { ...req.body }
+  putGift: async (req, res) => {
+    try {
+      const input = { ...req.body }
 
-  //     if (input.name.trim() === '') {
+      if (input.name.trim() === '') {
 
-  //       req.flash('error', '特典名稱不能為空白')
-  //       res.redirect('back')
+        req.flash('error', '特典名稱不能為空白')
+        res.redirect('back')
 
-  //     } else {
+      } else {
 
-  //       const id = +req.params.giftsid
-  //       await Tag.update(input, { where: { id } })
+        const id = +req.params.giftsid
+        await Gift.update(input, { where: { id } })
 
-  //       req.flash('success', '更新成功！')
-  //       res.redirect('/admin/gifts')
+        req.flash('success', '更新成功！')
+        res.redirect('/admin/gifts')
 
-  //     }
+      }
 
-  //   } catch (err) {
-  //     console.error(err)
-  //     res.status(500).json(err.toString())
-  //   }
-  // },
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
 
   // deleteTag: async (req, res) => {
   //   try {

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -1,0 +1,84 @@
+const db = require('../../models')
+const { Gift } = db
+
+
+module.exports = {
+  getGifts: async (req, res) => {
+    try {
+
+      const gifts = await Gift.findAll({
+        order: [['id', 'ASC']]
+      })
+      console.log(gifts)
+      res.render('admin/gifts', { gifts })
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  },
+
+  // postTags: async (req, res) => {
+  //   try {
+  //     const input = { ...req.body }
+  //     if (input.name.trim() === '') {
+
+  //       req.flash('error', '標籤名稱不能為空白')
+  //       res.redirect('/admin/tags')
+
+  //     } else {
+
+  //       const maxId = await Tag.max('id')
+  //       await Tag.create({ id: maxId + 1, ...input })
+
+  //       req.flash('success', '新增成功！')
+  //       res.redirect('/admin/tags')
+
+  //     }
+
+  //   } catch (err) {
+  //     console.error(err)
+  //     res.status(500).json(err.toString())
+  //   }
+  // },
+
+  // putTag: async (req, res) => {
+  //   try {
+  //     const input = { ...req.body }
+
+  //     if (input.name.trim() === '') {
+
+  //       req.flash('error', '標籤名稱不能為空白')
+  //       res.redirect('back')
+
+  //     } else {
+
+  //       const id = +req.params.tagsid
+  //       await Tag.update(input, { where: { id } })
+
+  //       req.flash('success', '更新成功！')
+  //       res.redirect('/admin/tags')
+
+  //     }
+
+  //   } catch (err) {
+  //     console.error(err)
+  //     res.status(500).json(err.toString())
+  //   }
+  // },
+
+  // deleteTag: async (req, res) => {
+  //   try {
+
+  //     const id = +req.params.tagsid
+  //     await Tag.destroy({ where: { id } })
+
+  //     req.flash('success', '刪除成功！')
+  //     res.redirect('/admin/tags')
+
+  //   } catch (err) {
+  //     console.error(err)
+  //     res.status(500).json(err.toString())
+  //   }
+  // },
+
+}

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -18,7 +18,7 @@ module.exports = {
         }
       });
 
-      res.render('admin/gifts', { gifts })
+      res.render('admin/gifts', { gifts , js:'upload'})
     } catch (err) {
       console.error(err)
       res.status(500).json(err.toString())

--- a/public/js/upload.js
+++ b/public/js/upload.js
@@ -1,14 +1,15 @@
 $("#image").change(function () {
-  readURL(this);
+  readImgUrl(this);
 })
 
 
-function readURL(input) {
+function readImgUrl(input) {
   if (input.files && input.files[0]) {
-    let reader = new FileReader();
+    console.log(input.files)
+    let reader = new FileReader()
     reader.onload = function (e) {
-      $("#preview_img").attr('src', e.target.result);
+      $("#preview_img").attr('src', e.target.result)
     }
-    reader.readAsDataURL(input.files[0]);
+    reader.readAsDataURL(input.files[0])
   }
 }

--- a/public/js/upload.js
+++ b/public/js/upload.js
@@ -3,12 +3,29 @@ $("#image").change(function () {
 })
 
 
+$(document).on('change', '.inputImg', function () {
+  showEditImg(this)
+})
+
+
 function readImgUrl(input) {
   if (input.files && input.files[0]) {
 
     let reader = new FileReader()
     reader.onload = function (e) {
       $("#preview_img").attr('src', e.target.result)
+    }
+    reader.readAsDataURL(input.files[0])
+
+  }
+}
+
+function showEditImg(input) {
+  if (input.files && input.files[0]) {
+
+    let reader = new FileReader()
+    reader.onload = function (e) {
+      input.nextElementSibling.src =  e.target.result
     }
     reader.readAsDataURL(input.files[0])
 

--- a/public/js/upload.js
+++ b/public/js/upload.js
@@ -1,0 +1,14 @@
+$("#image").change(function () {
+  readURL(this);
+})
+
+
+function readURL(input) {
+  if (input.files && input.files[0]) {
+    let reader = new FileReader();
+    reader.onload = function (e) {
+      $("#preview_img").attr('src', e.target.result);
+    }
+    reader.readAsDataURL(input.files[0]);
+  }
+}

--- a/public/js/upload.js
+++ b/public/js/upload.js
@@ -5,11 +5,12 @@ $("#image").change(function () {
 
 function readImgUrl(input) {
   if (input.files && input.files[0]) {
-    console.log(input.files)
+
     let reader = new FileReader()
     reader.onload = function (e) {
       $("#preview_img").attr('src', e.target.result)
     }
     reader.readAsDataURL(input.files[0])
+
   }
 }

--- a/routes/admin/gifts.js
+++ b/routes/admin/gifts.js
@@ -3,7 +3,7 @@ const giftCtrller = require('../../controllers/admin/giftCtrller')
 
 // route base '/admin/series
 router.get('/', giftCtrller.getGifts)
-// router.post('/', giftCtrller.postGifts)
+router.post('/', giftCtrller.postGifts)
 // router.put('/:giftsid', giftCtrller.putGifts)
 // router.delete('/:giftsid', giftCtrller.deleteGifts)
 

--- a/routes/admin/gifts.js
+++ b/routes/admin/gifts.js
@@ -5,6 +5,6 @@ const giftCtrller = require('../../controllers/admin/giftCtrller')
 router.get('/', giftCtrller.getGifts)
 router.post('/', giftCtrller.postGift)
 router.put('/:giftsid', giftCtrller.putGift)
-// router.delete('/:giftsid', giftCtrller.deleteGifts)
+router.delete('/:giftsid', giftCtrller.deleteGift)
 
 module.exports = router

--- a/routes/admin/gifts.js
+++ b/routes/admin/gifts.js
@@ -1,9 +1,12 @@
 const router = require('express').Router()
 const giftCtrller = require('../../controllers/admin/giftCtrller')
 
+const multer = require('multer')
+const upload = multer({ dest: 'temp/' })
+
 // route base '/admin/series
 router.get('/', giftCtrller.getGifts)
-router.post('/', giftCtrller.postGift)
+router.post('/', upload.single('image'), giftCtrller.postGift)
 router.put('/:giftsid', giftCtrller.putGift)
 router.delete('/:giftsid', giftCtrller.deleteGift)
 

--- a/routes/admin/gifts.js
+++ b/routes/admin/gifts.js
@@ -7,7 +7,7 @@ const upload = multer({ dest: 'temp/' })
 // route base '/admin/series
 router.get('/', giftCtrller.getGifts)
 router.post('/', upload.single('image'), giftCtrller.postGift)
-router.put('/:giftsid', giftCtrller.putGift)
+router.put('/:giftsid', upload.single('image'), giftCtrller.putGift)
 router.delete('/:giftsid', giftCtrller.deleteGift)
 
 module.exports = router

--- a/routes/admin/gifts.js
+++ b/routes/admin/gifts.js
@@ -1,0 +1,10 @@
+const router = require('express').Router()
+const giftCtrller = require('../../controllers/admin/giftCtrller')
+
+// route base '/admin/series
+router.get('/', giftCtrller.getGifts)
+// router.post('/', giftCtrller.postGifts)
+// router.put('/:giftsid', giftCtrller.putGifts)
+// router.delete('/:giftsid', giftCtrller.deleteGifts)
+
+module.exports = router

--- a/routes/admin/gifts.js
+++ b/routes/admin/gifts.js
@@ -3,8 +3,8 @@ const giftCtrller = require('../../controllers/admin/giftCtrller')
 
 // route base '/admin/series
 router.get('/', giftCtrller.getGifts)
-router.post('/', giftCtrller.postGifts)
-// router.put('/:giftsid', giftCtrller.putGifts)
+router.post('/', giftCtrller.postGift)
+router.put('/:giftsid', giftCtrller.putGift)
 // router.delete('/:giftsid', giftCtrller.deleteGifts)
 
 module.exports = router

--- a/routes/admin/index.js
+++ b/routes/admin/index.js
@@ -19,5 +19,6 @@ router.use('/orders', require('./orders.js'))
 router.use('/tags', require('./tags.js'))
 router.use('/categories', require('./categories.js'))
 router.use('/series', require('./series.js'))
+router.use('/gifts' , require('./gifts.js'))
 
 module.exports = router

--- a/views/admin/Series.hbs
+++ b/views/admin/Series.hbs
@@ -11,7 +11,7 @@
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1">新增作品別</button>
         </form>
-        <div class="accordion" id="accordionEdit">
+        <div class="accordion mb-5" id="accordionEdit">
           <table data-toggle="table" id="table">
             <thead>
               <tr>

--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -11,7 +11,7 @@
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1">新增分類</button>
         </form>
-        <div class="accordion" id="accordionEdit">
+        <div class="accordion mb-5" id="accordionEdit">
           <table data-toggle="table" id="table">
             <thead>
               <tr>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -5,7 +5,7 @@
         <div class="alertBlock mb-2">
           {{> alert}}
         </div>
-        <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
+        <form class="form-inline d-flex justify-content-end" action="/admin/gifts" method="POST">
           <div class="form-group mx-sm-3 mb-2 mt-1">
             <input type="text" class="form-control input-center" name="name" placeholder="輸入新特典..." required>
           </div>
@@ -76,12 +76,11 @@
                       <i class="fas fa-pen"></i>
                     </div>
                   </td>
-                  <td>
-
+                  <td class="p-0">
                   </td>
                   <td class="p-0">
                     <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
-                      <form class="" action="/admin/tags/{{this.id}}?_method=PUT" method="POST" id="edit_{{this.id}}">
+                      <form class="" action="/admin/gifts/{{this.id}}?_method=PUT" method="POST" id="edit_{{this.id}}">
                         <div class="form-group mx-sm-3 mb-2 mt-1">
                           <input type="text" class="form-control input-center" name="name" placeholder="輸入特典名稱..."
                             value='{{this.name}}' required>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -18,7 +18,7 @@
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1" id="">新增特典</button>
         </form>
-        <div class="accordion" id="accordionEdit">
+        <div class="accordion mb-5" id="accordionEdit">
           <table data-toggle="table" id="table">
             <thead>
               <tr>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -6,8 +6,14 @@
           {{> alert}}
         </div>
         <form class="form-inline d-flex justify-content-end" action="/admin/gifts" method="POST" enctype="multipart/form-data">
-            <input type="file" class="form-control-file float-left" id="image" name="image">      
-          <div class="form-group mx-sm-3 mb-2 mt-1">
+          <div class="d-flex align-items-center justify-content-center">
+            <img class="rounded mx-auto d-block" id="preview_img" src="" style="height:40px">
+            <label for="image">
+                <i class="fas fa-upload btn btn-light ml-2 mb-1 py-2"></i>
+            </label>
+            <input hidden type="file" id="image" name="image" >
+          </div>
+          <div class="form-group mx-sm-2 mb-2 mt-1 ml-sm-1">
             <input type="text" class="form-control input-center" name="name" placeholder="輸入新特典..." required>
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1">新增特典</button>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -86,10 +86,8 @@
                   <td class="p-0 text-center">
                     <div class="collapse row" id="collapse_{{this.id}}" data-parent="#accordionEdit">
                       <input hidden type="file" class="inputImg" id="imageEdit_{{this.id}}" name="image" form="edit_{{this.id}}">
-                      <img class="rounded ml-3 d-block editImg" src="" style="height:40px">
-                      <label for="imageEdit_{{this.id}}" class="mx-auto my-auto">
-                        <i class="fas fa-upload btn btn-light my-1 py-2"></i>
-                      </label>
+                      <img class="rounded mx-auto d-block editImg" src="" style="height:50px">
+
                     </div>
                   </td>
                   <td class="p-0">
@@ -104,7 +102,10 @@
                   </td>
                   <td class="p-0">
                     <div class="collapse text-center" id="collapse_{{this.id}}" data-parent="#accordionEdit">
-                      <button type="submit" class="btn btn-outline-dark mb-2 mt-1 px-4" form="edit_{{this.id}}">
+                      <label for="imageEdit_{{this.id}}" class="mx-auto my-auto">
+                        <i class="fas fa-upload btn btn-light mb-1 py-2"></i>
+                      </label>
+                      <button type="submit" class="btn btn-outline-dark mb-2 mt-1 px-3 ml-2" form="edit_{{this.id}}">
                         <i class="fas fa-level-down-alt fa-rotate-90"></i>
                       </button>
                     </div>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -5,7 +5,8 @@
         <div class="alertBlock mb-2">
           {{> alert}}
         </div>
-        <form class="form-inline d-flex justify-content-end" action="/admin/gifts" method="POST">
+        <form class="form-inline d-flex justify-content-end" action="/admin/gifts" method="POST" enctype="multipart/form-data">
+            <input type="file" class="form-control-file float-left" id="image" name="image">      
           <div class="form-group mx-sm-3 mb-2 mt-1">
             <input type="text" class="form-control input-center" name="name" placeholder="輸入新特典..." required>
           </div>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -84,12 +84,12 @@
                     </div>
                   </td>
                   <td class="p-0 text-center">
-                    <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
-                      {{!-- <img class="rounded mx-auto d-block editImg" src="" style="height:40px"> --}}
-                      <label for="imageEdit_{{this.id}}" class="mb-0">
+                    <div class="collapse row" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <input hidden type="file" class="inputImg" id="imageEdit_{{this.id}}" name="image" form="edit_{{this.id}}">
+                      <img class="rounded ml-3 d-block editImg" src="" style="height:40px">
+                      <label for="imageEdit_{{this.id}}" class="mx-auto my-auto">
                         <i class="fas fa-upload btn btn-light my-1 py-2"></i>
                       </label>
-                      <input hidden type="file" class="inputImg" id="imageEdit_{{this.id}}" name="image"  form="edit_{{this.id}}">
                     </div>
                   </td>
                   <td class="p-0">

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -7,7 +7,7 @@
         </div>
         <form class="form-inline d-flex justify-content-end" action="/admin/gifts" method="POST" enctype="multipart/form-data" id="newGift">
           <div class="d-flex align-items-center justify-content-center">
-            <img class="rounded mx-auto d-block" id="preview_img" src="" style="height:40px">
+            <img class="rounded mx-auto d-block" id="preview_img" name="preview_img" src="" style="height:40px">
             <label for="image">
                 <i class="fas fa-upload btn btn-light ml-2 mb-1 py-2"></i>
             </label>
@@ -85,10 +85,11 @@
                   </td>
                   <td class="p-0 text-center">
                     <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
-                      <label for="image" class="mb-0">
+                      {{!-- <img class="rounded mx-auto d-block editImg" src="" style="height:40px"> --}}
+                      <label for="imageEdit_{{this.id}}" class="mb-0">
                         <i class="fas fa-upload btn btn-light my-1 py-2"></i>
                       </label>
-                      <input hidden type="file" name="image" form="edit_{{this.id}}">
+                      <input hidden type="file" class="inputImg" id="imageEdit_{{this.id}}" name="image"  form="edit_{{this.id}}">
                     </div>
                   </td>
                   <td class="p-0">

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -5,18 +5,18 @@
         <div class="alertBlock mb-2">
           {{> alert}}
         </div>
-        <form class="form-inline d-flex justify-content-end" action="/admin/gifts" method="POST" enctype="multipart/form-data">
+        <form class="form-inline d-flex justify-content-end" action="/admin/gifts" method="POST" enctype="multipart/form-data" id="newGift">
           <div class="d-flex align-items-center justify-content-center">
             <img class="rounded mx-auto d-block" id="preview_img" src="" style="height:40px">
             <label for="image">
                 <i class="fas fa-upload btn btn-light ml-2 mb-1 py-2"></i>
             </label>
-            <input hidden type="file" id="image" name="image" >
+            <input hidden type="file" id="image" name="image" form="newGift">
           </div>
           <div class="form-group mx-sm-2 mb-2 mt-1 ml-sm-1">
             <input type="text" class="form-control input-center" name="name" placeholder="輸入新特典..." required>
           </div>
-          <button type="submit" class="btn btn-primary mb-2 mt-1">新增特典</button>
+          <button type="submit" class="btn btn-primary mb-2 mt-1" id="">新增特典</button>
         </form>
         <div class="accordion" id="accordionEdit">
           <table data-toggle="table" id="table">
@@ -83,11 +83,17 @@
                       <i class="fas fa-pen"></i>
                     </div>
                   </td>
-                  <td class="p-0">
+                  <td class="p-0 text-center">
+                    <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <label for="image" class="mb-0">
+                        <i class="fas fa-upload btn btn-light my-1 py-2"></i>
+                      </label>
+                      <input hidden type="file" name="image" form="edit_{{this.id}}">
+                    </div>
                   </td>
                   <td class="p-0">
                     <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
-                      <form class="" action="/admin/gifts/{{this.id}}?_method=PUT" method="POST" id="edit_{{this.id}}">
+                      <form class="" action="/admin/gifts/{{this.id}}?_method=PUT" method="POST" id="edit_{{this.id}}" enctype="multipart/form-data">
                         <div class="form-group mx-sm-3 mb-2 mt-1">
                           <input type="text" class="form-control input-center" name="name" placeholder="輸入特典名稱..."
                             value='{{this.name}}' required>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -56,11 +56,11 @@
                           <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
                             {{this.name}}</h5>
                           </br>
-                          <h5 class="text-danger text-right">你真的要刪除這則特典嗎？</h5>
+                          <h5 class="text-danger text-right">你真的要刪除這項特典嗎？</h5>
                         </div>
                         <div class="modal-footer">
                           <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
-                          <form action="/admin/tags/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                          <form action="/admin/gifts/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
                             <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
                             </button>
                           </form>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -1,0 +1,107 @@
+<main class="container">
+  <div class="card-body pt-4">
+    <div class="row col-12">
+      <div class="col-6 mx-auto">
+        <div class="alertBlock mb-2">
+          {{> alert}}
+        </div>
+        <form class="form-inline d-flex justify-content-end" action="/admin/tags" method="POST">
+          <div class="form-group mx-sm-3 mb-2 mt-1">
+            <input type="text" class="form-control input-center" name="name" placeholder="輸入新特典..." required>
+          </div>
+          <button type="submit" class="btn btn-primary mb-2 mt-1">新增特典</button>
+        </form>
+        <div class="accordion" id="accordionEdit">
+          <table data-toggle="table" id="table">
+            <thead>
+              <tr>
+                <th data-valign="middle" class="text-center" data-sortable="true" data-width="30">#</th>
+                <th data-valign="middle" class="text-center" data-sortable="true" data-width="50">特典圖片</th>
+                <th data-valign="middle" class="text-center" data-sortable="true" data-width="300">特典名稱</th>
+                <th data-valign="middle" class="text-center" data-width="150">特典操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{#each gifts}}
+                <tr>
+                  <td>{{this.id}}</td>
+                  <td>
+                    <img src="{{this.image}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="giftImage"
+                      style="height:50px">
+                  </td>
+                  <td>{{this.name}}</td>
+                  <td>
+                    <button class="text-decoration-none btn btn-outline-dark mx-1" type="button" data-toggle="collapse"
+                      data-target="#collapse_{{this.id}}">
+                      <i class="fas fa-edit" title="編輯特典資料"></i>
+                    </button>
+                    <!-- Delete Button trigger modal -->
+                    <button type="button" class="btn btn-outline-dark font-weight-normal mx-1" data-toggle="modal"
+                      data-target="#delete_{{this.id}}" title="刪除此特典">
+                      <i class="far fa-trash-alt" aria-hidden="true"></i>
+                    </button>
+                  </td>
+                  {{!-- Delete modal --}}
+                  <div class="modal fade" id="delete_{{this.id}}" tabindex="-1" role="dialog"
+                    aria-labelledby="delete_{{this.id}}Label" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <h5 class="modal-title" id="delete_{{this.id}}Label">刪除確認</h5>
+                          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                          </button>
+                        </div>
+                        <div class="modal-body">
+                          <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                            {{this.name}}</h5>
+                          </br>
+                          <h5 class="text-danger text-right">你真的要刪除這則特典嗎？</h5>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+                          <form action="/admin/tags/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+                            <button type="submit" class="btn btn-outline-danger font-weight-normal">確認刪除
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </tr>
+                {{!-- 更新用收合表單 --}}
+                <tr>
+                  <td class="p-0 text-center">
+                    <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <i class="fas fa-pen"></i>
+                    </div>
+                  </td>
+                  <td>
+
+                  </td>
+                  <td class="p-0">
+                    <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <form class="" action="/admin/tags/{{this.id}}?_method=PUT" method="POST" id="edit_{{this.id}}">
+                        <div class="form-group mx-sm-3 mb-2 mt-1">
+                          <input type="text" class="form-control input-center" name="name" placeholder="輸入特典名稱..."
+                            value='{{this.name}}' required>
+                        </div>
+                      </form>
+                    </div>
+                  </td>
+                  <td class="p-0">
+                    <div class="collapse text-center" id="collapse_{{this.id}}" data-parent="#accordionEdit">
+                      <button type="submit" class="btn btn-outline-dark mb-2 mt-1 px-4" form="edit_{{this.id}}">
+                        <i class="fas fa-level-down-alt fa-rotate-90"></i>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/views/admin/tags.hbs
+++ b/views/admin/tags.hbs
@@ -11,7 +11,7 @@
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1">新增標籤</button>
         </form>
-        <div class="accordion" id="accordionEdit">
+        <div class="accordion mb-5" id="accordionEdit">
           <table data-toggle="table" id="table">
             <thead>
               <tr>

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -68,6 +68,9 @@
       integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
       crossorigin="anonymous"></script>
     <script src="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.js"></script>
+      {{#if js}}
+        <script src="/js/{{js}}.js"></script>
+      {{/if}}
   </import>
 </body>
 

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -47,6 +47,9 @@
         <li class="nav-item">
           <a class="nav-link {{#ifEqual path '/series'}}active{{/ifEqual}}" href="/admin/series">作品別</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link {{#ifEqual path '/gifts'}}active{{/ifEqual}}" href="/admin/gifts">特典</a>
+        </li>
         <br>
       </ul>
       <a class="btn btn-outline-secondary ml-3" href="/users/signout">登出</a>


### PR DESCRIPTION

<img width="583" alt="螢幕快照 2020-01-13 下午5 06 38" src="https://user-images.githubusercontent.com/49901777/72243570-3b048d80-3627-11ea-9486-46fe8f9e77a3.png">

## PR內容
- 完成特典在後台的CRUD

## 手動測試
- admin帳號進入後台後，可以點擊特典連結瀏覽所有特典
- 表格上方可以新增一筆特典，可輸入名稱與上傳圖檔(限一張)
   - 圖檔非必填
   - 名稱有後端防空白
   - 點擊上傳按鈕可以展開檔案選擇視窗
   - 選擇圖片後，按鈕左側會出現預覽畫面
- 點擊一筆特典的編輯按鈕，會展開編輯欄位
   - 可以重新上傳特典圖片(預覽尚未實作，還在看array.change的方法...)
   - 可以重新編輯特典名稱
- 按下刪除按鈕可以刪除特典

## 延伸出的需求卡
- admin/product 的新增與編輯要增加選擇特典的功能
