### PR TITLE
【加入】後台 新增/修改商品的表單驗證

### DIFF
--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -113,6 +113,15 @@ module.exports = {
       input.SeriesId = +input.SeriesId
       input.CategoryId = +input.CategoryId
 
+      const error = checkProduct(input)
+
+      if (error) {
+        req.flash('error', error)
+        console.log('err',error)
+        req.flash('input', input)
+        console.log('errinput',input)
+        return res.redirect('/admin/products/new')
+      }
       const newProduct = await Product.create(input)
 
       //寫入TagItem

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -62,5 +62,13 @@ module.exports = {
       // 檢查商品是否有未填
       if (input[attr].length === 0) return `" * "資料為必填，缺少 ${attr}。`
     }
+    
+    // 檢查商品各項內文是否過長
+    if (input.name.length > 25) return '商品名稱不可超過 25 字'
+    if (input.slogan.length > 25) return '商品標語不可超過 25 字'
+    if (input.description.length > 200 ) return '商品內文不可超過 200 字'
+    if (input.spec.length > 50) return '商品規格不可超過 50 字'
+    if (input.copyright.length > 25) return '商品版權不可超過 25 字'
+    if (input.maker.length > 25) return '製造商不可超過 25 字'
   }
 }

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -58,12 +58,9 @@ module.exports = {
   },
 
   checkProduct: input => {
-  for (let attr in input) {
-    // 檢查商品是否有未填
-    if (input[attr].length === 0) {
-      return `所有資料為必填，缺少 ${attr}`
+    for (let attr in input) {
+      // 檢查商品是否有未填
+      if (input[attr].length === 0) return `" * "資料為必填，缺少 ${attr}。`
     }
-  }
-    
   }
 }

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -56,4 +56,14 @@ module.exports = {
     const isPhone = /^09\d{2}(-?\d{3}){2}$/.test(input.phone)
     if (!isPhone) return '手機號碼格式錯誤'
   },
+
+  checkProduct: input => {
+  for (let attr in input) {
+    // 檢查商品是否有未填
+    if (input[attr].length === 0) {
+      return `所有資料為必填，缺少 ${attr}`
+    }
+  }
+    
+  }
 }

--- a/public/css/admin/admin.css
+++ b/public/css/admin/admin.css
@@ -7,6 +7,12 @@
   max-width: 1250px;
 }
 
+.input-required::after {
+    color: red;
+    font-size: 18px;
+    content: " *";
+}
+
 main.container {
   padding-top: 56px;
 }

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -6,7 +6,9 @@
     enctype="multipart/form-data"
   ></form>
   <section class="pt-4">
-    {{> alert}}
+    <div class="alertBlock mb-2">
+      {{> alert}}
+    </div>
     <div class="card my-3">
       <div class="card-body">
         <h4>基本資訊</h4>

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -14,7 +14,7 @@
           <div class="form-group row">
             <label for="name" class="col-sm-2 col-form-label text-right input-required">商品名稱</label>
             <div class="col-sm-7">
-              <input type="text" name="name" class="form-control" id="name" value="{{product.name}}" form="editForm">
+              <input type="text" name="name" class="form-control" id="name" value="{{product.name}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -22,7 +22,7 @@
           <div class="form-group row">
             <label for="slogan" class="col-sm-2 col-form-label text-right input-required">商品標語</label>
             <div class="col-sm-7">
-              <input type="text" name="slogan" class="form-control" id="slogan" value="{{product.slogan}}" form="editForm">
+              <input type="text" name="slogan" class="form-control" id="slogan" value="{{product.slogan}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -30,7 +30,7 @@
           <div class="form-group row">
             <label for="description" class="col-sm-2 col-form-label text-right input-required">商品內文</label>
             <div class="col-sm-7">
-              <textarea class="form-control" name="description" id="description" rows="3" form="editForm">{{product.description}}</textarea>
+              <textarea class="form-control" name="description" id="description" rows="3" form="editForm" required>{{product.description}}</textarea>
             </div>
           </div>
         </div>
@@ -72,7 +72,7 @@
           <div class="form-group row">
             <label for="price" class="col-sm-2 col-form-label text-right input-required">商品售價</label>
             <div class="col-sm-7">
-              <input type="number" name="price" class="form-control" id="price" value="{{product.price}}" form="editForm">
+              <input type="number" name="price" class="form-control" id="price" value="{{product.price}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -80,7 +80,7 @@
           <div class="form-group row">
             <label for="inventory" class="col-sm-2 col-form-label text-right input-required">商品數量</label>
             <div class="col-sm-7">
-              <input type="number" name="inventory" class="form-control" id="inventory" value="{{product.inventory}}" form="editForm">
+              <input type="number" name="inventory" class="form-control" id="inventory" value="{{product.inventory}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -88,7 +88,7 @@
           <div class="form-group row">
             <label for="spec" class="col-sm-2 col-form-label text-right input-required">商品規格</label>
             <div class="col-sm-7">
-              <input type="text" name="spec" class="form-control" id="spec" value="{{product.spec}}" form="editForm">
+              <input type="text" name="spec" class="form-control" id="spec" value="{{product.spec}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -96,7 +96,7 @@
           <div class="form-group row">
             <label for="releaseDate" class="col-sm-2 col-form-label text-right input-required">公開日期</label>
             <div class="col-sm-7">
-              <input type="date" name="releaseDate" class="form-control" id="releaseDate" value="{{releaseDate}}" form="editForm">
+              <input type="date" name="releaseDate" class="form-control" id="releaseDate" value="{{releaseDate}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -104,7 +104,7 @@
           <div class="form-group row">
             <label for="deadline" class="col-sm-2 col-form-label text-right input-required">預購截止日期</label>
             <div class="col-sm-7">
-              <input type="date" name="deadline" class="form-control" id="deadline" value="{{deadline}}" form="editForm">
+              <input type="date" name="deadline" class="form-control" id="deadline" value="{{deadline}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -112,7 +112,7 @@
           <div class="form-group row">
             <label for="saleDate" class="col-sm-2 col-form-label text-right input-required">發售日期</label>
             <div class="col-sm-7">
-              <input type="date" name="saleDate" class="form-control" id="saleDate" value="{{saleDate}}" form="editForm">
+              <input type="date" name="saleDate" class="form-control" id="saleDate" value="{{saleDate}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -188,7 +188,7 @@
           <div class="form-group row">
             <label for="copyright" class="col-sm-2 col-form-label text-right input-required">版權</label>
             <div class="col-sm-7">
-              <input type="text" name="copyright" class="form-control" id="copyright" value="{{product.copyright}}" form="editForm">
+              <input type="text" name="copyright" class="form-control" id="copyright" value="{{product.copyright}}" form="editForm" required>
             </div>
           </div>
         </div>
@@ -196,7 +196,7 @@
           <div class="form-group row">
             <label for="maker" class="col-sm-2 col-form-label text-right input-required">廠商</label>
             <div class="col-sm-7">
-              <input type="text" name="maker" class="form-control" id="maker" value="{{product.maker}}" form="editForm">
+              <input type="text" name="maker" class="form-control" id="maker" value="{{product.maker}}" form="editForm" required>
             </div>
           </div>
         </div>

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -12,7 +12,7 @@
         <h4>基本資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="name" class="col-sm-2 col-form-label text-right">商品名稱</label>
+            <label for="name" class="col-sm-2 col-form-label text-right input-required">商品名稱</label>
             <div class="col-sm-7">
               <input type="text" name="name" class="form-control" id="name" value="{{product.name}}" form="editForm">
             </div>
@@ -20,7 +20,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="slogan" class="col-sm-2 col-form-label text-right">商品標語</label>
+            <label for="slogan" class="col-sm-2 col-form-label text-right input-required">商品標語</label>
             <div class="col-sm-7">
               <input type="text" name="slogan" class="form-control" id="slogan" value="{{product.slogan}}" form="editForm">
             </div>
@@ -28,7 +28,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="description" class="col-sm-2 col-form-label text-right">商品內文</label>
+            <label for="description" class="col-sm-2 col-form-label text-right input-required">商品內文</label>
             <div class="col-sm-7">
               <textarea class="form-control" name="description" id="description" rows="3" form="editForm">{{product.description}}</textarea>
             </div>
@@ -36,7 +36,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="category" class="col-sm-2 col-form-label text-right">商品分類</label>
+            <label for="category" class="col-sm-2 col-form-label text-right input-required">商品分類</label>
             <div class="col-sm-7">
               <select class="form-control" name="CategoryId" id="category" form="editForm">
                 {{#each categories}}
@@ -50,7 +50,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="tag" class="col-sm-2 col-form-label text-right">商品標籤</label>
+            <label for="tag" class="col-sm-2 col-form-label text-right">商品標籤&nbsp;&nbsp;</label>
             <div class="col-sm-7 d-flex align-items-center">
               {{#each tag}}
                 <div class="form-check form-check-inline">
@@ -70,7 +70,7 @@
         <h4>銷售資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="price" class="col-sm-2 col-form-label text-right">商品售價</label>
+            <label for="price" class="col-sm-2 col-form-label text-right input-required">商品售價</label>
             <div class="col-sm-7">
               <input type="number" name="price" class="form-control" id="price" value="{{product.price}}" form="editForm">
             </div>
@@ -78,7 +78,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="inventory" class="col-sm-2 col-form-label text-right">商品數量</label>
+            <label for="inventory" class="col-sm-2 col-form-label text-right input-required">商品數量</label>
             <div class="col-sm-7">
               <input type="number" name="inventory" class="form-control" id="inventory" value="{{product.inventory}}" form="editForm">
             </div>
@@ -86,7 +86,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="spec" class="col-sm-2 col-form-label text-right">商品規格</label>
+            <label for="spec" class="col-sm-2 col-form-label text-right input-required">商品規格</label>
             <div class="col-sm-7">
               <input type="text" name="spec" class="form-control" id="spec" value="{{product.spec}}" form="editForm">
             </div>
@@ -94,7 +94,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="releaseDate" class="col-sm-2 col-form-label text-right">公開日期</label>
+            <label for="releaseDate" class="col-sm-2 col-form-label text-right input-required">公開日期</label>
             <div class="col-sm-7">
               <input type="date" name="releaseDate" class="form-control" id="releaseDate" value="{{releaseDate}}" form="editForm">
             </div>
@@ -102,7 +102,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="deadline" class="col-sm-2 col-form-label text-right">預購截止日期</label>
+            <label for="deadline" class="col-sm-2 col-form-label text-right input-required">預購截止日期</label>
             <div class="col-sm-7">
               <input type="date" name="deadline" class="form-control" id="deadline" value="{{deadline}}" form="editForm">
             </div>
@@ -110,7 +110,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="saleDate" class="col-sm-2 col-form-label text-right">發售日期</label>
+            <label for="saleDate" class="col-sm-2 col-form-label text-right input-required">發售日期</label>
             <div class="col-sm-7">
               <input type="date" name="saleDate" class="form-control" id="saleDate" value="{{saleDate}}" form="editForm">
             </div>
@@ -118,7 +118,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="status" class="col-sm-2 col-form-label text-right">商品是否上架</label>
+            <label for="status" class="col-sm-2 col-form-label text-right input-required">商品是否上架</label>
             <div class="col-sm-7">
               <select class="form-control" name="status" id="status" form="editForm">
                 <option value="1" {{#ifEqual ture product.status}} selected {{/ifEqual}}>是</option>
@@ -129,7 +129,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="image" class="col-sm-2 col-form-label text-right">新增商品圖片</label>
+            <label for="image" class="col-sm-2 col-form-label text-right input-required">新增商品圖片</label>
             <div>
               <div class="custom-file col-sm-7 d-flex align-items-center">
                 <input type="file" name="image" multiple="multiple" id="image" form="editForm">
@@ -139,7 +139,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="image" class="col-2 col-form-label text-right">圖片管理</label>
+            <label for="image" class="col-2 col-form-label text-right input-required">圖片管理</label>
             <div class="col-10 pl-0">
               <div class="form-check form-check-inline mr-0 pl-2 col-10 d-flex flex-wrap">
                 {{#each images}}
@@ -173,7 +173,7 @@
         <h4>其他資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="series" class="col-sm-2 col-form-label text-right">隸屬作品</label>
+            <label for="series" class="col-sm-2 col-form-label text-right input-required">隸屬作品</label>
             <div class="col-sm-7">
               <select class="form-control" name="SeriesId" id="series" form="editForm">
                 {{#each series}}
@@ -186,7 +186,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="copyright" class="col-sm-2 col-form-label text-right">版權</label>
+            <label for="copyright" class="col-sm-2 col-form-label text-right input-required">版權</label>
             <div class="col-sm-7">
               <input type="text" name="copyright" class="form-control" id="copyright" value="{{product.copyright}}" form="editForm">
             </div>
@@ -194,7 +194,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="maker" class="col-sm-2 col-form-label text-right">廠商</label>
+            <label for="maker" class="col-sm-2 col-form-label text-right input-required">廠商</label>
             <div class="col-sm-7">
               <input type="text" name="maker" class="form-control" id="maker" value="{{product.maker}}" form="editForm">
             </div>

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -6,6 +6,7 @@
     enctype="multipart/form-data"
   ></form>
   <section class="pt-4">
+    {{> alert}}
     <div class="card my-3">
       <div class="card-body">
         <h4>基本資訊</h4>
@@ -13,7 +14,7 @@
           <div class="form-group row">
             <label for="name" class="col-sm-2 col-form-label text-right">商品名稱</label>
             <div class="col-sm-7">
-              <input type="text" name="name" class="form-control" id="name" value='{{product.name}}' form="editForm">
+              <input type="text" name="name" class="form-control" id="name" value="{{product.name}}" form="editForm">
             </div>
           </div>
         </div>
@@ -21,7 +22,7 @@
           <div class="form-group row">
             <label for="slogan" class="col-sm-2 col-form-label text-right">商品標語</label>
             <div class="col-sm-7">
-              <input type="text" name="slogan" class="form-control" id="slogan" value='{{product.slogan}}' form="editForm">
+              <input type="text" name="slogan" class="form-control" id="slogan" value="{{product.slogan}}" form="editForm">
             </div>
           </div>
         </div>
@@ -39,7 +40,7 @@
             <div class="col-sm-7">
               <select class="form-control" name="CategoryId" id="category" form="editForm">
                 {{#each categories}}
-                  <option value={{this.id}} {{#ifEqual this.id ../product.CategoryId}} selected {{/ifEqual}}>
+                  <option value="{{this.id}}" {{#ifEqual this.id ../product.CategoryId}} selected {{/ifEqual}}>
                     {{this.name}}
                   </option>
                 {{/each}}
@@ -71,7 +72,7 @@
           <div class="form-group row">
             <label for="price" class="col-sm-2 col-form-label text-right">商品售價</label>
             <div class="col-sm-7">
-              <input type="number" name="price" class="form-control" id="price" value={{product.price}} form="editForm">
+              <input type="number" name="price" class="form-control" id="price" value="{{product.price}}" form="editForm">
             </div>
           </div>
         </div>
@@ -79,7 +80,7 @@
           <div class="form-group row">
             <label for="inventory" class="col-sm-2 col-form-label text-right">商品數量</label>
             <div class="col-sm-7">
-              <input type="number" name="inventory" class="form-control" id="inventory" value={{product.inventory}} form="editForm">
+              <input type="number" name="inventory" class="form-control" id="inventory" value="{{product.inventory}}" form="editForm">
             </div>
           </div>
         </div>
@@ -87,7 +88,7 @@
           <div class="form-group row">
             <label for="spec" class="col-sm-2 col-form-label text-right">商品規格</label>
             <div class="col-sm-7">
-              <input type="text" name="spec" class="form-control" id="spec" value='{{product.spec}}' form="editForm">
+              <input type="text" name="spec" class="form-control" id="spec" value="{{product.spec}}" form="editForm">
             </div>
           </div>
         </div>
@@ -95,7 +96,7 @@
           <div class="form-group row">
             <label for="releaseDate" class="col-sm-2 col-form-label text-right">公開日期</label>
             <div class="col-sm-7">
-              <input type="date" name="releaseDate" class="form-control" id="releaseDate" value={{releaseDate}} form="editForm">
+              <input type="date" name="releaseDate" class="form-control" id="releaseDate" value="{{releaseDate}}" form="editForm">
             </div>
           </div>
         </div>
@@ -103,7 +104,7 @@
           <div class="form-group row">
             <label for="deadline" class="col-sm-2 col-form-label text-right">預購截止日期</label>
             <div class="col-sm-7">
-              <input type="date" name="deadline" class="form-control" id="deadline" value={{deadline}} form="editForm">
+              <input type="date" name="deadline" class="form-control" id="deadline" value="{{deadline}}" form="editForm">
             </div>
           </div>
         </div>
@@ -111,7 +112,7 @@
           <div class="form-group row">
             <label for="saleDate" class="col-sm-2 col-form-label text-right">發售日期</label>
             <div class="col-sm-7">
-              <input type="date" name="saleDate" class="form-control" id="saleDate" value={{saleDate}} form="editForm">
+              <input type="date" name="saleDate" class="form-control" id="saleDate" value="{{saleDate}}" form="editForm">
             </div>
           </div>
         </div>
@@ -176,7 +177,7 @@
             <div class="col-sm-7">
               <select class="form-control" name="SeriesId" id="series" form="editForm">
                 {{#each series}}
-                  <option value={{this.id}} {{#ifEqual this.id ../product.SeriesId}}selected{{/ifEqual}}>{{this.name}}
+                  <option value="{{this.id}}" {{#ifEqual this.id ../product.SeriesId}}selected{{/ifEqual}}>{{this.name}}
                   </option>
                 {{/each}}
               </select>
@@ -187,7 +188,7 @@
           <div class="form-group row">
             <label for="copyright" class="col-sm-2 col-form-label text-right">版權</label>
             <div class="col-sm-7">
-              <input type="text" name="copyright" class="form-control" id="copyright" value='{{product.copyright}}' form="editForm">
+              <input type="text" name="copyright" class="form-control" id="copyright" value="{{product.copyright}}" form="editForm">
             </div>
           </div>
         </div>
@@ -195,7 +196,7 @@
           <div class="form-group row">
             <label for="maker" class="col-sm-2 col-form-label text-right">廠商</label>
             <div class="col-sm-7">
-              <input type="text" name="maker" class="form-control" id="maker" value='{{product.maker}}' form="editForm">
+              <input type="text" name="maker" class="form-control" id="maker" value="{{product.maker}}" form="editForm">
             </div>
           </div>
         </div>

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -13,7 +13,7 @@
           <div class="form-group row">
             <label for="name" class="col-sm-2 col-form-label text-right">商品名稱</label>
             <div class="col-sm-7">
-              <input type="text" name="name" class="form-control" id="name" value={{product.name}} form="editForm">
+              <input type="text" name="name" class="form-control" id="name" value='{{product.name}}' form="editForm">
             </div>
           </div>
         </div>
@@ -21,7 +21,7 @@
           <div class="form-group row">
             <label for="slogan" class="col-sm-2 col-form-label text-right">商品標語</label>
             <div class="col-sm-7">
-              <input type="text" name="slogan" class="form-control" id="slogan" value={{product.slogan}} form="editForm">
+              <input type="text" name="slogan" class="form-control" id="slogan" value='{{product.slogan}}' form="editForm">
             </div>
           </div>
         </div>
@@ -87,7 +87,7 @@
           <div class="form-group row">
             <label for="spec" class="col-sm-2 col-form-label text-right">商品規格</label>
             <div class="col-sm-7">
-              <input type="text" name="spec" class="form-control" id="spec" value={{product.spec}} form="editForm">
+              <input type="text" name="spec" class="form-control" id="spec" value='{{product.spec}}' form="editForm">
             </div>
           </div>
         </div>
@@ -187,7 +187,7 @@
           <div class="form-group row">
             <label for="copyright" class="col-sm-2 col-form-label text-right">版權</label>
             <div class="col-sm-7">
-              <input type="text" name="copyright" class="form-control" id="copyright" value={{product.copyright}} form="editForm">
+              <input type="text" name="copyright" class="form-control" id="copyright" value='{{product.copyright}}' form="editForm">
             </div>
           </div>
         </div>
@@ -195,7 +195,7 @@
           <div class="form-group row">
             <label for="maker" class="col-sm-2 col-form-label text-right">廠商</label>
             <div class="col-sm-7">
-              <input type="text" name="maker" class="form-control" id="maker" value={{product.maker}} form="editForm">
+              <input type="text" name="maker" class="form-control" id="maker" value='{{product.maker}}' form="editForm">
             </div>
           </div>
         </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -8,7 +8,7 @@
           <div class="form-group row">
             <label for="name" class="col-sm-2 col-form-label text-right input-required">商品名稱</label>
             <div class="col-sm-7">
-              <input type="text" name="name" class="form-control" id="name" value="{{product.name}}">
+              <input type="text" name="name" class="form-control" id="name" value="{{product.name}}" required>
             </div>
           </div>
         </div>
@@ -16,7 +16,7 @@
           <div class="form-group row">
             <label for="slogan" class="col-sm-2 col-form-label text-right  input-required">商品標語</label>
             <div class="col-sm-7">
-              <input type="text" name="slogan" class="form-control" id="slogan" value="{{product.slogan}}">
+              <input type="text" name="slogan" class="form-control" id="slogan" value="{{product.slogan}}" required>
             </div>
           </div>
         </div>
@@ -24,7 +24,7 @@
           <div class="form-group row">
             <label for="description" class="col-sm-2 col-form-label text-right input-required">商品內文</label>
             <div class="col-sm-7">
-              <textarea class="form-control" name="description" id="description" rows="3">{{product.description}}</textarea>
+              <textarea class="form-control" name="description" id="description" rows="3" required>{{product.description}}</textarea>
             </div>
           </div>
         </div>
@@ -62,7 +62,7 @@
           <div class="form-group row">
             <label for="price" class="col-sm-2 col-form-label text-right input-required">商品售價</label>
             <div class="col-sm-7">
-              <input type="number" name="price" class="form-control" id="price" value="{{product.price}}">
+              <input type="number" name="price" class="form-control" id="price" value="{{product.price}}" required>
             </div>
           </div>
         </div>
@@ -70,7 +70,7 @@
           <div class="form-group row">
             <label for="inventory" class="col-sm-2 col-form-label text-right input-required">商品庫存</label>
             <div class="col-sm-7">
-              <input type="number" name="inventory" class="form-control" id="inventory" value="{{product.inventory}}">
+              <input type="number" name="inventory" class="form-control" id="inventory" value="{{product.inventory}}" required>
             </div>
           </div>
         </div>
@@ -78,7 +78,7 @@
           <div class="form-group row">
             <label for="spec" class="col-sm-2 col-form-label text-right input-required">商品規格</label>
             <div class="col-sm-7">
-              <input type="text" name="spec" class="form-control" id="spec" value="{{product.spec}}">
+              <input type="text" name="spec" class="form-control" id="spec" value="{{product.spec}}" required>
             </div>
           </div>
         </div>
@@ -86,7 +86,7 @@
           <div class="form-group row">
             <label for="releaseDate" class="col-sm-2 col-form-label text-right input-required">公開日期</label>
             <div class="col-sm-7">
-              <input type="date" name="releaseDate" class="form-control" id="releaseDate" value="{{product.releaseDate}}">
+              <input type="date" name="releaseDate" class="form-control" id="releaseDate" value="{{product.releaseDate}}" required>
             </div>
           </div>
         </div>
@@ -94,7 +94,7 @@
           <div class="form-group row">
             <label for="deadline" class="col-sm-2 col-form-label text-right input-required">預購截止日期</label>
             <div class="col-sm-7">
-              <input type="date" name="deadline" class="form-control" id="deadline" value="{{product.deadline}}">
+              <input type="date" name="deadline" class="form-control" id="deadline" value="{{product.deadline}}" required>
             </div>
           </div>
         </div>
@@ -102,7 +102,7 @@
           <div class="form-group row">
             <label for="saleDate" class="col-sm-2 col-form-label text-right input-required">發售日期</label>
             <div class="col-sm-7">
-              <input type="date" name="saleDate" class="form-control" id="saleDate" value="{{product.saleDate}}">
+              <input type="date" name="saleDate" class="form-control" id="saleDate" value="{{product.saleDate}}" required>
             </div>
           </div>
         </div>
@@ -122,7 +122,7 @@
             <label for="image" class="col-sm-2 col-form-label text-right input-required">商品圖片</label>
             <div>
               <div class="custom-file col-sm-7 d-flex align-items-center">
-                <input type="file" name="image" multiple="multiple" id="image">
+                <input type="file" name="image" multiple="multiple" id="image" required>
               </div>
               <small id="emailHelp" class="form-text text-muted ml-3">
                 <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>
@@ -151,7 +151,7 @@
           <div class="form-group row">
             <label for="copyright" class="col-sm-2 col-form-label text-right input-required">版權所屬</label>
             <div class="col-sm-7">
-              <input type="text" name="copyright" class="form-control" id="copyright" value="{{product.copyright}}">
+              <input type="text" name="copyright" class="form-control" id="copyright" value="{{product.copyright}}" required>
             </div>
           </div>
         </div>
@@ -159,7 +159,7 @@
           <div class="form-group row">
             <label for="maker" class="col-sm-2 col-form-label text-right input-required">製造商</label>
             <div class="col-sm-7">
-              <input type="text" name="maker" class="form-control" id="maker" value="{{product.maker}}">
+              <input type="text" name="maker" class="form-control" id="maker" value="{{product.maker}}" required>
             </div>
           </div>
         </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -1,6 +1,8 @@
 <main class="container">
   <form class="pt-4" action="/admin/products" method="POST" enctype="multipart/form-data">
-  {{> alert}}
+  <div class="alertBlock mb-2">
+    {{> alert}}
+  </div>
     <div class="card my-3">
       <div class="card-body">
         <h4>基本資訊</h4>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -1,5 +1,6 @@
 <main class="container">
   <form class="pt-4" action="/admin/products" method="POST" enctype="multipart/form-data">
+  {{> alert}}
     <div class="card my-3">
       <div class="card-body">
         <h4>基本資訊</h4>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -6,7 +6,7 @@
         <h4>基本資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="name" class="col-sm-2 col-form-label text-right">商品名稱</label>
+            <label for="name" class="col-sm-2 col-form-label text-right input-required">商品名稱</label>
             <div class="col-sm-7">
               <input type="text" name="name" class="form-control" id="name" value="{{product.name}}">
             </div>
@@ -14,7 +14,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="slogan" class="col-sm-2 col-form-label text-right">商品標語</label>
+            <label for="slogan" class="col-sm-2 col-form-label text-right  input-required">商品標語</label>
             <div class="col-sm-7">
               <input type="text" name="slogan" class="form-control" id="slogan" value="{{product.slogan}}">
             </div>
@@ -22,7 +22,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="description" class="col-sm-2 col-form-label text-right">商品內文</label>
+            <label for="description" class="col-sm-2 col-form-label text-right input-required">商品內文</label>
             <div class="col-sm-7">
               <textarea class="form-control" name="description" id="description" rows="3">{{product.description}}</textarea>
             </div>
@@ -30,7 +30,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="category" class="col-sm-2 col-form-label text-right">商品分類</label>
+            <label for="category" class="col-sm-2 col-form-label text-right input-required">商品分類</label>
             <div class="col-sm-7">
               <select class="form-control" name="CategoryId" id="category">
                 {{#each categories}}
@@ -42,7 +42,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="tag" class="col-sm-2 col-form-label text-right">商品標籤</label>
+            <label for="tag" class="col-sm-2 col-form-label text-right">商品標籤&nbsp;&nbsp;</label>
             <div class="col-sm-7 d-flex align-items-center">
               {{#each tag}}
                 <div class="form-check form-check-inline">
@@ -60,7 +60,7 @@
         <h4>銷售資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="price" class="col-sm-2 col-form-label text-right">商品售價</label>
+            <label for="price" class="col-sm-2 col-form-label text-right input-required">商品售價</label>
             <div class="col-sm-7">
               <input type="number" name="price" class="form-control" id="price" value="{{product.price}}">
             </div>
@@ -68,7 +68,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="inventory" class="col-sm-2 col-form-label text-right">商品庫存</label>
+            <label for="inventory" class="col-sm-2 col-form-label text-right input-required">商品庫存</label>
             <div class="col-sm-7">
               <input type="number" name="inventory" class="form-control" id="inventory" value="{{product.inventory}}">
             </div>
@@ -76,7 +76,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="spec" class="col-sm-2 col-form-label text-right">商品規格</label>
+            <label for="spec" class="col-sm-2 col-form-label text-right input-required">商品規格</label>
             <div class="col-sm-7">
               <input type="text" name="spec" class="form-control" id="spec" value="{{product.spec}}">
             </div>
@@ -84,7 +84,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="releaseDate" class="col-sm-2 col-form-label text-right">公開日期</label>
+            <label for="releaseDate" class="col-sm-2 col-form-label text-right input-required">公開日期</label>
             <div class="col-sm-7">
               <input type="date" name="releaseDate" class="form-control" id="releaseDate" value="{{product.releaseDate}}">
             </div>
@@ -92,7 +92,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="deadline" class="col-sm-2 col-form-label text-right">預購截止日期</label>
+            <label for="deadline" class="col-sm-2 col-form-label text-right input-required">預購截止日期</label>
             <div class="col-sm-7">
               <input type="date" name="deadline" class="form-control" id="deadline" value="{{product.deadline}}">
             </div>
@@ -100,7 +100,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="saleDate" class="col-sm-2 col-form-label text-right">發售日期</label>
+            <label for="saleDate" class="col-sm-2 col-form-label text-right input-required">發售日期</label>
             <div class="col-sm-7">
               <input type="date" name="saleDate" class="form-control" id="saleDate" value="{{product.saleDate}}">
             </div>
@@ -108,7 +108,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="status" class="col-sm-2 col-form-label text-right">商品是否上架</label>
+            <label for="status" class="col-sm-2 col-form-label text-right input-required">商品是否上架</label>
             <div class="col-sm-7">
               <select class="form-control" name="status" id="status">
                 <option value="1">是</option>
@@ -119,7 +119,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="image" class="col-sm-2 col-form-label text-right">商品圖片</label>
+            <label for="image" class="col-sm-2 col-form-label text-right input-required">商品圖片</label>
             <div>
               <div class="custom-file col-sm-7 d-flex align-items-center">
                 <input type="file" name="image" multiple="multiple" id="image">
@@ -137,7 +137,7 @@
         <h4>其他資訊</h4>
         <div class="px-5">
           <div class="form-group row">
-            <label for="series" class="col-sm-2 col-form-label text-right">隸屬作品</label>
+            <label for="series" class="col-sm-2 col-form-label text-right input-required">隸屬作品</label>
             <div class="col-sm-7">
               <select class="form-control" name="SeriesId" id="series">
                 {{#each series}}
@@ -149,7 +149,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="copyright" class="col-sm-2 col-form-label text-right">版權所屬</label>
+            <label for="copyright" class="col-sm-2 col-form-label text-right input-required">版權所屬</label>
             <div class="col-sm-7">
               <input type="text" name="copyright" class="form-control" id="copyright" value="{{product.copyright}}">
             </div>
@@ -157,7 +157,7 @@
         </div>
         <div class="px-5">
           <div class="form-group row">
-            <label for="maker" class="col-sm-2 col-form-label text-right">製造商</label>
+            <label for="maker" class="col-sm-2 col-form-label text-right input-required">製造商</label>
             <div class="col-sm-7">
               <input type="text" name="maker" class="form-control" id="maker" value="{{product.maker}}">
             </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -8,7 +8,7 @@
           <div class="form-group row">
             <label for="name" class="col-sm-2 col-form-label text-right">商品名稱</label>
             <div class="col-sm-7">
-              <input type="text" name="name" class="form-control" id="name">
+              <input type="text" name="name" class="form-control" id="name" value="{{product.name}}">
             </div>
           </div>
         </div>
@@ -16,7 +16,7 @@
           <div class="form-group row">
             <label for="slogan" class="col-sm-2 col-form-label text-right">商品標語</label>
             <div class="col-sm-7">
-              <input type="text" name="slogan" class="form-control" id="slogan">
+              <input type="text" name="slogan" class="form-control" id="slogan" value="{{product.slogan}}">
             </div>
           </div>
         </div>
@@ -24,7 +24,7 @@
           <div class="form-group row">
             <label for="description" class="col-sm-2 col-form-label text-right">商品內文</label>
             <div class="col-sm-7">
-              <textarea class="form-control" name="description" id="description" rows="3"></textarea>
+              <textarea class="form-control" name="description" id="description" rows="3">{{product.description}}</textarea>
             </div>
           </div>
         </div>
@@ -62,7 +62,7 @@
           <div class="form-group row">
             <label for="price" class="col-sm-2 col-form-label text-right">商品售價</label>
             <div class="col-sm-7">
-              <input type="number" name="price" class="form-control" id="price">
+              <input type="number" name="price" class="form-control" id="price" value="{{product.price}}">
             </div>
           </div>
         </div>
@@ -70,7 +70,7 @@
           <div class="form-group row">
             <label for="inventory" class="col-sm-2 col-form-label text-right">商品庫存</label>
             <div class="col-sm-7">
-              <input type="number" name="inventory" class="form-control" id="inventory">
+              <input type="number" name="inventory" class="form-control" id="inventory" value="{{product.inventory}}">
             </div>
           </div>
         </div>
@@ -78,7 +78,7 @@
           <div class="form-group row">
             <label for="spec" class="col-sm-2 col-form-label text-right">商品規格</label>
             <div class="col-sm-7">
-              <input type="text" name="spec" class="form-control" id="spec">
+              <input type="text" name="spec" class="form-control" id="spec" value="{{product.spec}}">
             </div>
           </div>
         </div>
@@ -86,7 +86,7 @@
           <div class="form-group row">
             <label for="releaseDate" class="col-sm-2 col-form-label text-right">公開日期</label>
             <div class="col-sm-7">
-              <input type="date" name="releaseDate" class="form-control" id="releaseDate">
+              <input type="date" name="releaseDate" class="form-control" id="releaseDate" value="{{product.releaseDate}}">
             </div>
           </div>
         </div>
@@ -94,7 +94,7 @@
           <div class="form-group row">
             <label for="deadline" class="col-sm-2 col-form-label text-right">預購截止日期</label>
             <div class="col-sm-7">
-              <input type="date" name="deadline" class="form-control" id="deadline">
+              <input type="date" name="deadline" class="form-control" id="deadline" value="{{product.deadline}}">
             </div>
           </div>
         </div>
@@ -102,7 +102,7 @@
           <div class="form-group row">
             <label for="saleDate" class="col-sm-2 col-form-label text-right">發售日期</label>
             <div class="col-sm-7">
-              <input type="date" name="saleDate" class="form-control" id="saleDate">
+              <input type="date" name="saleDate" class="form-control" id="saleDate" value="{{product.saleDate}}">
             </div>
           </div>
         </div>
@@ -151,7 +151,7 @@
           <div class="form-group row">
             <label for="copyright" class="col-sm-2 col-form-label text-right">版權所屬</label>
             <div class="col-sm-7">
-              <input type="text" name="copyright" class="form-control" id="copyright">
+              <input type="text" name="copyright" class="form-control" id="copyright" value="{{product.copyright}}">
             </div>
           </div>
         </div>
@@ -159,7 +159,7 @@
           <div class="form-group row">
             <label for="maker" class="col-sm-2 col-form-label text-right">製造商</label>
             <div class="col-sm-7">
-              <input type="text" name="maker" class="form-control" id="maker">
+              <input type="text" name="maker" class="form-control" id="maker" value="{{product.maker}}">
             </div>
           </div>
         </div>


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/50958992/72282151-07e9ea80-3677-11ea-8dfa-f13fc33b91c6.png)

## 內容
- 後台 新增商品頁 與 修改商品頁的表單驗證
- 如有輸入有以下錯誤將會跳出 alert
  - 是否有未填的項目 (需拿掉前台 input 的 `required` 驗證)
  - input 的內容是否過多
  - 新增商品時是否有一張商品圖
- 增加必填的 `*` 符號 (`class ="input-required"` 新增在 admin.css)

## 確認目標
- 新增或修改時，除了 tag ，其他都應該為必填項目
  - 新增商品時，至少需上傳一張商品圖
  - 可透過 DevTools 拿掉 input 的 `required` ，如有未填的項目將會跳出 alert
- input 無法輸入過多的內容，超過限制將會跳出 alert
  - 商品名稱、標語、內文、規格、版權、製造商
- 如有任何錯誤，填的資料都應保留住
- 保留 alert 位置，顯示 alert 訊息時，表單位置不會移動
- 確認必填項目應都有 `*` 標示 
![2](https://user-images.githubusercontent.com/50958992/72282152-07e9ea80-3677-11ea-9941-9c80f9bdb144.png)

## 未解決
- 新增時，當如果有錯誤，只有圖片部分還未保留前一次上傳的內容，將需要重新上傳一次圖片