### PR TITLE
【加入】後台產品上傳前預覽圖片

### DIFF
--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -58,7 +58,7 @@ module.exports = {
         })
       ])
 
-      res.render('admin/new', { categories, series, tag })
+      res.render('admin/new', { categories, series, tag, js:'admin/product'})
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -200,7 +200,8 @@ module.exports = {
         saleDate,
         deadline,
         tagItem,
-        images
+        images,
+        js: 'admin/product'
       })
     } catch (err) {
       console.error(err)

--- a/public/js/admin/product.js
+++ b/public/js/admin/product.js
@@ -1,25 +1,10 @@
 $("#image").change(function () {
-  console.log('yo')
   readImgUrl(this);
 })
 
-// function readImgUrl(input) {
-//   if (input.files && input.files[0]) {
-
-//     let reader = new FileReader()
-//     reader.onload = function (e) {
-//       $("#preview_img").attr('src', e.target.result)
-//     }
-//     reader.readAsDataURL(input.files[0])
-
-//   }
-// }
-
 function readImgUrl(input) {
   if (input.files && input.files.length >= 0) {
-    console.log('in')
     for (let i = 0; i < input.files.length; i++) {
-      console.log(i)
       let reader = new FileReader();
       reader.onload = function (e) {
         let img = `
@@ -29,8 +14,6 @@ function readImgUrl(input) {
           </label>
         </div>
         `
-        // $("<img width='200' height='150'>").attr('src', e.target.result);
-        console.log(img)
         $('#images').append(img);
       }
       reader.readAsDataURL(input.files[i]);

--- a/public/js/admin/product.js
+++ b/public/js/admin/product.js
@@ -23,7 +23,7 @@ function readImgUrl(input) {
       let reader = new FileReader();
       reader.onload = function (e) {
         let img = `
-        <div class="mx-2">
+        <div class="mx-1">
           <label class="d-block">
             <img src=${e.target.result} class="img-thumbnail mx-1" style="width: 100px">
           </label>

--- a/public/js/admin/product.js
+++ b/public/js/admin/product.js
@@ -1,0 +1,39 @@
+$("#image").change(function () {
+  console.log('yo')
+  readImgUrl(this);
+})
+
+// function readImgUrl(input) {
+//   if (input.files && input.files[0]) {
+
+//     let reader = new FileReader()
+//     reader.onload = function (e) {
+//       $("#preview_img").attr('src', e.target.result)
+//     }
+//     reader.readAsDataURL(input.files[0])
+
+//   }
+// }
+
+function readImgUrl(input) {
+  if (input.files && input.files.length >= 0) {
+    console.log('in')
+    for (let i = 0; i < input.files.length; i++) {
+      console.log(i)
+      let reader = new FileReader();
+      reader.onload = function (e) {
+        let img = `
+        <div class="mx-2">
+          <label class="d-block">
+            <img src=${e.target.result} class="img-thumbnail mx-1" style="width: 100px">
+          </label>
+        </div>
+        `
+        // $("<img width='200' height='150'>").attr('src', e.target.result);
+        console.log(img)
+        $('#images').append(img);
+      }
+      reader.readAsDataURL(input.files[i]);
+    }
+  }
+}

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -136,7 +136,7 @@
                 </label>
                 <input type="file" name="image" multiple="multiple" id="image" form="editForm" hidden>
               </div>
-              <div id="images" class="d-flex justify-content-around align-items-center"></div>
+              <div id="images" class="d-flex justify-content-around align-items-center pl-2"></div>
             </div>
           </div>
         </div>
@@ -146,7 +146,7 @@
             <div class="col-10 pl-0">
               <div class="form-check form-check-inline mr-0 pl-2 col-10 d-flex flex-wrap">
                 {{#each images}}
-                  <div class="text-center mr-1 position-relative">
+                  <div class="text-center mx-1 position-relative">
                     <input id="{{this.id}}" class="input-hidden" type="radio" name="mainImg" value="{{this.id}}" form="editForm">
                     <label for="{{this.id}}" class="d-block">
                       <img src={{this.url}} class="img-thumbnail mx-1" style="width: 100px">

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -129,14 +129,17 @@
         <div class="px-5">
           <div class="form-group row">
             <label for="image" class="col-sm-2 col-form-label text-right">新增商品圖片</label>
-            <div>
+            <div class="col-10 pl-0">
               <div class="custom-file col-sm-7 d-flex align-items-center">
                 <label for="image">
                   <i class="fas fa-upload btn btn-light mt-2 py-2"></i>
                 </label>
-                <input type="file" name="image" multiple="multiple" id="image" form="editForm" hidden>
+                <input type="file" name="image" multiple="multiple" id="image" hidden>
               </div>
-              <div id="images" class="d-flex justify-content-around align-items-center pl-2"></div>
+              <div id="images" class="form-check form-check-inline mr-0 pl-2 col-10 d-flex flex-wrap"></div>
+              <small id="emailHelp" class="form-text text-muted ml-3">
+                <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>
+              </small>
             </div>
           </div>
         </div>

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -136,6 +136,7 @@
                 </label>
                 <input type="file" name="image" multiple="multiple" id="image" form="editForm" hidden>
               </div>
+              <div id="images" class="d-flex justify-content-around align-items-center"></div>
             </div>
           </div>
         </div>

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -131,7 +131,10 @@
             <label for="image" class="col-sm-2 col-form-label text-right">新增商品圖片</label>
             <div>
               <div class="custom-file col-sm-7 d-flex align-items-center">
-                <input type="file" name="image" multiple="multiple" id="image" form="editForm">
+                <label for="image">
+                  <i class="fas fa-upload btn btn-light mt-2 py-2"></i>
+                </label>
+                <input type="file" name="image" multiple="multiple" id="image" form="editForm" hidden>
               </div>
             </div>
           </div>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -121,7 +121,10 @@
             <label for="image" class="col-sm-2 col-form-label text-right">商品圖片</label>
             <div>
               <div class="custom-file col-sm-7 d-flex align-items-center">
-                <input type="file" name="image" multiple="multiple" id="image">
+                <label for="image">
+                  <i class="fas fa-upload btn btn-light mt-2 py-2"></i>
+                </label>
+                <input type="file" name="image" multiple="multiple" id="image" hidden>
               </div>
               <small id="emailHelp" class="form-text text-muted ml-3">
                 <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -126,7 +126,7 @@
                 </label>
                 <input type="file" name="image" multiple="multiple" id="image" hidden>
               </div>
-              <div id="images" class="d-flex justify-content-around align-items-center"></div>
+              <div id="images" class="d-flex justify-content-around align-items-center pl-2"></div>
               <small id="emailHelp" class="form-text text-muted ml-3">
                 <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>
               </small>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -1,5 +1,5 @@
 <main class="container">
-  <form class="pt-4" action="/admin/products" method="POST" enctype="multipart/form-data">
+  <form class="pt-4" action="/admin/products" method="POST" enctype="multipart/form-data" id="newProuuct">
     <div class="card my-3">
       <div class="card-body">
         <h4>基本資訊</h4>
@@ -126,7 +126,7 @@
                 </label>
                 <input type="file" name="image" multiple="multiple" id="image" hidden>
               </div>
-              <div id="images" class="d-flex justify-content-around align-items-center pl-2"></div>
+              <div id="images" class="d-flex align-items-center pl-2"></div>
               <small id="emailHelp" class="form-text text-muted ml-3">
                 <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>
               </small>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -119,14 +119,14 @@
         <div class="px-5">
           <div class="form-group row">
             <label for="image" class="col-sm-2 col-form-label text-right">商品圖片</label>
-            <div>
+            <div class="col-10 pl-0">
               <div class="custom-file col-sm-7 d-flex align-items-center">
                 <label for="image">
                   <i class="fas fa-upload btn btn-light mt-2 py-2"></i>
                 </label>
                 <input type="file" name="image" multiple="multiple" id="image" hidden>
               </div>
-              <div id="images" class="d-flex align-items-center pl-2"></div>
+              <div id="images" class="form-check form-check-inline mr-0 pl-2 col-10 d-flex flex-wrap"></div>
               <small id="emailHelp" class="form-text text-muted ml-3">
                 <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>
               </small>

--- a/views/admin/new.hbs
+++ b/views/admin/new.hbs
@@ -126,6 +126,7 @@
                 </label>
                 <input type="file" name="image" multiple="multiple" id="image" hidden>
               </div>
+              <div id="images" class="d-flex justify-content-around align-items-center"></div>
               <small id="emailHelp" class="form-text text-muted ml-3">
                 <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>
               </small>

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -66,6 +66,9 @@
       crossorigin="anonymous"></script>
     <script src="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.js"></script>
   </import>
+  {{#if js}}
+    <script src="/js/{{js}}.js"></script>
+  {{/if}}
 </body>
 
 </html>


### PR DESCRIPTION
<img width="860" alt="螢幕快照 2020-01-14 下午4 57 10" src="https://user-images.githubusercontent.com/49901777/72329385-99953e80-36ef-11ea-8e7c-02e054431d7b.png">

## PR內容
- 後台新增/編輯產品時，上傳圖片可以顯示已選擇的圖片
- 可同時選取多張一併顯示

## 手動確認
- 新增商品頁面，選擇圖片後可以看到即時預覽出現並正常新增商品圖片
- 編輯商品頁面，選擇圖片後可以看到即時預覽出現並正常更新商品圖片
- 圖片選擇較多時有warp效果換行排列

## 其他
- 要刪除未上傳的特定檔案似乎有點麻煩