### PR TITLE
【加入】User 綁定購物車

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -10,15 +10,17 @@ passport.use(new LocalStrategy(
     passwordField: 'password'
   },
 
-  (email, password, done) => {
-    User.findOne({ where: { email } })
-      .then(user => {
-        if (!user) return done(null, false, { message: '帳號或密碼輸入錯誤' })
-        if (!bcrypt.compareSync(password, user.password)) return done(null, false, { message: '帳號或密碼輸入錯誤' })
+  async (email, password, done) => {
+    try {
+      const user = await User.findOne({ where: { email } })
+      if (!user) return done(null, false, { message: '帳號或密碼輸入錯誤' })
 
-        done(null, user)
-      })
-      .catch(err => console.error(err))
+      const isSuccess = bcrypt.compareSync(password, user.password)
+      if (!isSuccess) return done(null, false, { message: '帳號或密碼輸入錯誤' })
+
+      done(null, user, { message: 'success' })
+
+    } catch (err) { console.error(err) }
   }
 ))
 
@@ -27,10 +29,9 @@ passport.serializeUser((user, done) => {
   done(null, user.id)
 })
 passport.deserializeUser((id, done) => {
-  User.findByPk(id, {
-    include: [{ all: true, nested: false }]
-  })
+  User.findByPk(id)
     .then(user => done(null, user))
+    .catch(err => console.error(err))
 })
 
 module.exports = passport

--- a/controllers/cartCtrller.js
+++ b/controllers/cartCtrller.js
@@ -159,4 +159,24 @@ module.exports = {
       res.status(500).json({ status: 'serverError', message: err.toString() })
     }
   },
+
+  setCart: async (req, res) => {
+    try {
+      // 當前購物車，綁給 user
+      const cartId = req.session.cartId
+      if (cartId) {
+        const cart = await Cart.findByPk(cartId)
+        await cart.update({ UserId: req.user.id })
+      }
+
+      // 如已有購物車，合併
+      // const cartItems = await CartItem.findAll({ where: { CartId: cartId } })
+
+      res.redirect('/admin')
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  },
 }

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -152,7 +152,10 @@ module.exports = {
       product.hasInv = (product.inventory !== 0)
       product.category = product.Category.name
 
-      res.render('product', { css: 'product', js: 'product', product })
+      res.render('product', { 
+        css: 'product', js: 'product', product,
+        useSlick: true, useLightbox: true
+      })
 
     } catch (err) {
       console.error(err)

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -55,19 +55,12 @@ module.exports = {
         req.flash('error', info.message)
         return res.redirect(`/users/signin${from}`)
       }
+
       req.logIn(user, err => {
         if (err) return console.error(err)
-        next(from)
+        next()
       })
     })(req, res, next)
-
-    // passport.authenticate('local', {
-    //   successRedirect: from ? '/orders/checkout' : '/admin',
-    //   successFlash: true,
-    //   failureRedirect: `/users/signin${from}`,
-    //   failureFlash: true,
-    //   badRequestMessage: '請輸入 Email 與 Password'
-    // })(req, res, next)
   },
 
   signOut: async (req, res) => {

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -27,11 +27,7 @@ module.exports = {
       await User.create(input)
 
       // 自動登入
-      passport.authenticate('local', {
-        successRedirect: '/admin',
-        failureRedirect: `/users/signin`,
-        failureFlash: true,
-      })(req, res, next)
+      next()
 
     } catch (err) {
       console.error(err)
@@ -50,7 +46,7 @@ module.exports = {
     const from = req.body.from || ''
 
     passport.authenticate('local', {
-      successRedirect: '/admin',
+      successRedirect: from ? '/orders/checkout' : '/admin',
       successFlash: true,
       failureRedirect: `/users/signin${from}`,
       failureFlash: true,

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -70,7 +70,11 @@ module.exports = {
     // })(req, res, next)
   },
 
-  signOut: (req, res) => {
+  signOut: async (req, res) => {
+    // 歸還購物車
+    delete req.session.cartId
+    await req.session.save()
+
     req.logout()
     res.redirect('/')
   },

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -45,13 +45,29 @@ module.exports = {
     // 判斷來源頁面
     const from = req.body.from || ''
 
-    passport.authenticate('local', {
-      successRedirect: from ? '/orders/checkout' : '/admin',
-      successFlash: true,
-      failureRedirect: `/users/signin${from}`,
-      failureFlash: true,
-      badRequestMessage: '請輸入 Email 與 Password'
+    const option = {
+      badRequestMessage: '請輸入 Email 與 Password',
+    }
+
+    passport.authenticate('local', option, async (err, user, info) => {
+      if (err) return console.error(err)
+      if (!user) {
+        req.flash('error', info.message)
+        return res.redirect(`/users/signin${from}`)
+      }
+      req.logIn(user, err => {
+        if (err) return console.error(err)
+        next(from)
+      })
     })(req, res, next)
+
+    // passport.authenticate('local', {
+    //   successRedirect: from ? '/orders/checkout' : '/admin',
+    //   successFlash: true,
+    //   failureRedirect: `/users/signin${from}`,
+    //   failureFlash: true,
+    //   badRequestMessage: '請輸入 Email 與 Password'
+    // })(req, res, next)
   },
 
   signOut: (req, res) => {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -14,7 +14,7 @@ module.exports = {
     if (!req.isAuthenticated()) return res.redirect('/users/signin')
 
     // 確認用戶權限
-    if (!req.user.isAdmin) return res.redirect('/users/profile')
+    if (!req.user.isAdmin) return res.redirect('/cart')
     next()
   }
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,7 +1,11 @@
 
 module.exports = {
   isAuth: (req, res, next) => {
-    if (!req.isAuthenticated()) return res.redirect('/users/signin')
+    if (!req.isAuthenticated()) {
+      if (req.path === '/checkout') return res.redirect('/users/signin/checkout')
+
+      return res.redirect('/users/signin')
+    }
     next()
   },
 

--- a/migrations/20191226032053-create-cart.js
+++ b/migrations/20191226032053-create-cart.js
@@ -8,6 +8,9 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.INTEGER
       },
+      user_id: {
+        type: Sequelize.INTEGER
+      },
       created_at: {
         allowNull: false,
         type: Sequelize.DATE,

--- a/models/cart.js
+++ b/models/cart.js
@@ -1,6 +1,7 @@
 'use strict';
 module.exports = (sequelize, DataTypes) => {
   const Cart = sequelize.define('Cart', {
+    UserId: DataTypes.INTEGER,
   }, {});
   Cart.associate = function(models) {
     Cart.hasMany(models.CartItem, { onDelete: 'cascade', hooks: true })

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -9,6 +9,17 @@ body {
   min-height: 100vh;
 }
 
+.container {
+  min-width: 1250px;
+  width: 1250px;
+}
+
+.top-bar {
+  width: 100%;
+  min-width: 1250px;
+  background-color: #fff;
+}
+
 .btn-top-bar {
   background-color: #ff9600;
   border: 1px solid #ff9600;
@@ -40,6 +51,8 @@ body {
 
 .category-bar, footer {
   background-color: #806d66;
+  width: 100%;
+  min-width: 1250px;
 }
 
 .footer-item {
@@ -55,11 +68,6 @@ body {
 }
 .footer-link:hover {
   color:#ffffff;
-}
-
-.category-bar .navbar {
-  padding-right: 0;
-  padding-left: 0;
 }
 
 .category-bar .nav-link {
@@ -82,6 +90,8 @@ body {
 
 .search-bar {
   background-color: #b7a69f;
+  width: 100%;
+  min-width: 1250px;
 }
 
 .footer-muted{

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -153,6 +153,10 @@ body {
   text-align: center;
 }
 
+.alert-success .alert-msg {
+  white-space: pre-line;
+}
+
 .alert-danger {
   color: #ff4d39;
   font-size: 12px;

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -72,23 +72,9 @@ section {
   content: "\f054";
 }
 
-@media screen and (max-width: 1199.98px) {
-  .gallery-main {
-    width: 400px;
-    height: 506px;
-  }
-}
-
 @media screen and (max-width: 991.98px) {
   .gallery-nav {
     width: 50%;
-  }
-}
-
-@media screen and (max-width: 767.98px) {
-  .gallery-main {
-    width: 350px;
-    height: 442px;
   }
 }
 

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -79,14 +79,16 @@ section {
   }
 }
 
+@media screen and (max-width: 991.98px) {
+  .gallery-nav {
+    width: 50%;
+  }
+}
+
 @media screen and (max-width: 767.98px) {
   .gallery-main {
     width: 350px;
     height: 442px;
-  }
-
-  .gallery-nav {
-    width: 100%;
   }
 }
 

--- a/public/css/products.css
+++ b/public/css/products.css
@@ -52,8 +52,7 @@
 }
 
 .card-bg {
-  width: 166px;
-  height: 210px;
+  height: 242.71px;
   background-color: #eee;
 }
 
@@ -80,12 +79,6 @@
 
 .icon-group {
   padding-top: 100px;
-}
-
-.img-fit {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
 }
 
 .nav-tag {
@@ -134,39 +127,4 @@
 .tag-sold-out {
   background-color: #9E9E9F;
   color: #ffffff;
-}
-
-/* define bootstrap 5 columns */
-.col-xs-2-5,
-.col-sm-2-5,
-.col-md-2-5,
-.col-lg-2-5 {
-    position: relative;
-    min-height: 1px;
-    padding-right: 10px;
-    padding-left: 10px;
-}
-
-.col-xs-2-5 {
-    width: 20%;
-    float: left;
-}
-
-@media (min-width: 768px) {
-.col-sm-2-5 {
-        width: 20%;
-        float: left;
-    }
-}
-@media (min-width: 992px) {
-    .col-md-2-5 {
-        width: 20%;
-        float: left;
-    }
-}
-@media (min-width: 1200px) {
-    .col-lg-2-5 {
-        width: 20%;
-        float: left;
-    }
 }

--- a/public/css/sign.css
+++ b/public/css/sign.css
@@ -18,7 +18,7 @@
 .panel {
   background-color: #ffffff;
   border-radius: 20px;
-  margin: 0 15px;
+  margin: 0 0;
 }
 
 .panel-item {

--- a/routes/users.js
+++ b/routes/users.js
@@ -4,7 +4,7 @@ const { isAuth } = require('../middleware/auth')
 
 // route base '/users'
 router.get('/', (req, res) => res.send('users page'))
-router.post('/signup', userCtrller.signUp)
+router.post('/signup', userCtrller.signUp, userCtrller.signIn)
 router.get('/signin', userCtrller.getSignIn)
 router.get('/signin/checkout', userCtrller.getSignIn)
 router.post('/signin', userCtrller.signIn)

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,13 +1,14 @@
 const router = require('express').Router()
-const userCtrller = require('../controllers/userCtrller')
-const { isAuth } = require('../middleware/auth')
+const userCtrller = require('../controllers/userCtrller.js')
+const cartCtrller = require('../controllers/cartCtrller.js')
+const { isAuth } = require('../middleware/auth.js')
 
 // route base '/users'
 router.get('/', (req, res) => res.send('users page'))
 router.post('/signup', userCtrller.signUp, userCtrller.signIn)
 router.get('/signin', userCtrller.getSignIn)
 router.get('/signin/checkout', userCtrller.getSignIn)
-router.post('/signin', userCtrller.signIn)
+router.post('/signin', userCtrller.signIn, cartCtrller.setCart)
 router.get('/signout', userCtrller.signOut)
 
 router.get('/profile', isAuth, userCtrller.getProfile)

--- a/seeders/20191218121809-gift-seeder.js
+++ b/seeders/20191218121809-gift-seeder.js
@@ -6,7 +6,7 @@ module.exports = {
     return queryInterface.bulkInsert('gifts',
       Array.from({ length: 5 }, (val, index) => ({
         name: faker.commerce.productName(),
-        image: faker.image.image(),
+        image: `https://picsum.photos/seed/gift${index + 1}/360/400`,
         product_id: index + 1
       }))
     )

--- a/views/cart.hbs
+++ b/views/cart.hbs
@@ -1,5 +1,5 @@
 <div class="container py-5">
-  <div class="row">
+  <div class="row mb-5">
     {{!-- 購物車內容 --}}
     <main class="col-9" role="main">
       <div class="panel mx-1">

--- a/views/cart.hbs
+++ b/views/cart.hbs
@@ -13,8 +13,8 @@
           <div class="cart-product">
             {{!-- 標題 --}}
             <div class="row">
-              <div class="col-md-7 item-title">商品{{cartProducts.length}}</div>
-              <div class="col-md-5 item-title">
+              <div class="col-7 item-title">商品{{cartProducts.length}}</div>
+              <div class="col-5 item-title">
                 <div class="d-flex justify-content-between align-items-center">
                   <span>商品價格</span>
                   <span>數量</span>
@@ -26,7 +26,7 @@
             {{!-- 內文 --}}
             {{#each cartProducts}}
               <div class="row">
-                <div class="col-md-7 d-flex align-items-start">
+                <div class="col-7 d-flex align-items-start">
                   <div>
                     <a href="/products/{{this.id}}" class="product-img">
                       <img src="{{this.mainImg}}" class="img-fit">
@@ -55,7 +55,7 @@
                     </form>
                   </div>
                 </div>
-                <div class="col-md-5 font-format">
+                <div class="col-5 font-format">
                   <div class="d-flex justify-content-between align-items-center note-flag">
                     <span>NTD {{this.priceFormat}}</span>
                     <span>
@@ -77,10 +77,10 @@
           {{!-- 總計區塊 --}}
           <div class="cart-amount">
             <div class="row">
-              <div class="col-md-7 font-format">
+              <div class="col-7 font-format">
                 <div>購物車 ID : {{cart.id}}</div>
               </div>
-              <div class="col-md-5 font-format">
+              <div class="col-5 font-format">
                 <div class="d-flex justify-content-between align-items-center">
                   <span>小計</span>
                   <span>NTD {{totalPriceFormat}}</span>

--- a/views/checkout_1.hbs
+++ b/views/checkout_1.hbs
@@ -1,5 +1,5 @@
 <div class="container py-5">
-  <div class="row">
+  <div class="row mb-5">
     {{!-- 主內容 --}}
     <main class="col-8" role="main">
       <div class="panel">

--- a/views/checkout_2.hbs
+++ b/views/checkout_2.hbs
@@ -1,5 +1,5 @@
 <div class="container py-5">
-  <div class="row">
+  <div class="row mb-5">
     {{!-- 主內容 --}}
     <main class="col-8" role="main">
       <section class="panel">

--- a/views/checkout_3.hbs
+++ b/views/checkout_3.hbs
@@ -1,5 +1,5 @@
 <div class="container py-5">
-  <div class="row">
+  <div class="row mb-5">
     {{!-- 主內容 --}}
     <main class="col-8" role="main">
       <div class="panel">

--- a/views/checkout_4.hbs
+++ b/views/checkout_4.hbs
@@ -1,5 +1,5 @@
 <div class="container py-5">
-  <div class="row">
+  <div class="row mb-5">
     {{!-- 主內容 --}}
     <main class="col-8" role="main">
       <div class="panel">

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -23,10 +23,8 @@
 <body>
   {{> header}}
   {{>cartAlert}}
-  <div class="content">
-    {{{body}}}
-  </div>
-  <footer class="w-100 mt-auto py-3 text-center">
+  {{{body}}}
+  <footer class="mt-auto py-3 text-center">
     <a href="jquery:;" class="back-top">
       <i class="fas fa-chevron-up"></i>
     </a>

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -10,9 +10,13 @@
     integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.1/css/all.min.css">
   <link href="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.1/css/lightbox.min.css">
+  {{#if useSlick}}
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css">
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css">
+  {{/if}}
+  {{#if useLightbox}}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.1/css/lightbox.min.css">
+  {{/if}}
   <link rel="stylesheet" href="/css/main.css">
   {{#if css}}
     <link rel="stylesheet" href="/css/{{css}}.css">
@@ -52,12 +56,18 @@
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
       integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-      crossorigin="anonymous"></script>
+      crossorigin="anonymous"
+    ></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
       integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
-      crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.1/js/lightbox.min.js"></script>
+      crossorigin="anonymous"
+    ></script>
+    {{#if useSlick}}
+      <script src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
+    {{/if}}
+    {{#if useLightbox}}
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.1/js/lightbox.min.js"></script>
+    {{/if}}
   </import>
   <script src="/js/main.js"></script>
   {{#if js}}

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -1,7 +1,7 @@
-<main class="container pt-2 pb-5">
-  <div class="row">
+<main class="container py-5">
+  <div class="row mb-5">
     {{!-- 主卡片 --}}
-    <section class="col-md-9 mb-5 p-3">
+    <section class="col-9">
       <div class="row panel mx-1">
         <div class="panel-heading col-md-12">
           <div class="mt-3">訂購紀錄</div>
@@ -164,7 +164,7 @@
       <br>
     </section>
     {{!-- 側邊欄 --}}
-    <section class="col-md-3 mb-5 p-3">
+    <section class="col-3">
       <div class="row panel mx-1 side-box-shadow">
         <div class="panel-body w-100 p-3">
           <div>

--- a/views/partials/alert.hbs
+++ b/views/partials/alert.hbs
@@ -1,6 +1,6 @@
 {{#if success}}
   <div class="alert alert-success">
-    <strong>{{success}}</strong>
+    <strong class="alert-msg">{{success}}</strong>
   </div>
 {{else if error}}
   <div class="alert alert-danger">

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -1,5 +1,5 @@
-<nav class="navbar navbar-light p-0" id="navbar">
-  <div class="w-100 bg-white">
+<header id="navbar" class="navbar navbar-light p-0">
+  <div class="top-bar">
     <div class="container py-3">
       <a href="/" class="navbar-brand">LOGO</a>
       <div>
@@ -21,33 +21,33 @@
       </div>
     </div>
   </div>
-  <div class="container-fluid category-bar">
-    <ul class="nav mx-auto">
-      <li class="nav-item px-3">
-        <a class="nav-link py-4 {{#if isAllProducts}}active{{/if}}" 
-        href="/products">製品一覽</a>
-      </li>
-      <li class="nav-item px-3">
-        <a class="nav-link py-4 {{#ifEqual categoryQuery 'Figure'}}active{{/ifEqual}}" 
-        href="/products?category=Figure">Figure</a>
-      </li>
-      <li class="nav-item px-3">
-        <a class="nav-link py-4 {{#ifEqual categoryQuery '豆丁人'}}active{{/ifEqual}}" 
-        href="/products?category=豆丁人">豆丁人</a>
-      </li>
-      <li class="nav-item px-3">
-        <a class="nav-link py-4 {{#ifEqual categoryQuery 'Figma'}}active{{/ifEqual}}" 
-        href="/products?category=Figma">Figma</a>
-      </li>
-      <li class="nav-item px-3">
-        <a class="nav-link py-4 {{#ifEqual categoryQuery '組裝模型(仮)'}}active{{/ifEqual}}" 
-        href="/products?category=組裝模型(仮)">組裝模型(仮)</a>
-      </li>
-    </ul>
-  </div>
-  <div class="container-fluid py-2 search-bar">
-    <div class="row mx-auto">
-      <div class="col-md-12 ">
+  <nav class="category-bar">
+    <div class="container">
+      <ul class="nav mx-auto">
+        <li class="nav-item px-3">
+          <a class="nav-link py-4 {{#if isAllProducts}}active{{/if}}" href="/products">製品一覽</a>
+        </li>
+        <li class="nav-item px-3">
+          <a class="nav-link py-4 {{#ifEqual categoryQuery 'Figure'}}active{{/ifEqual}}"
+            href="/products?category=Figure">Figure</a>
+        </li>
+        <li class="nav-item px-3">
+          <a class="nav-link py-4 {{#ifEqual categoryQuery '豆丁人'}}active{{/ifEqual}}" href="/products?category=豆丁人">豆丁人</a>
+        </li>
+        <li class="nav-item px-3">
+          <a class="nav-link py-4 {{#ifEqual categoryQuery 'Figma'}}active{{/ifEqual}}"
+            href="/products?category=Figma">Figma</a>
+        </li>
+        <li class="nav-item px-3">
+          <a class="nav-link py-4 {{#ifEqual categoryQuery '組裝模型(仮)'}}active{{/ifEqual}}"
+            href="/products?category=組裝模型(仮)">組裝模型(仮)</a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+  <div class="search-bar">
+    <div class="py-2 container">
+      <div class="w-50 mx-auto">
         <form action="/search" method="GET">
           <div class="input-group">
             <input type="text" name="q" class="form-control search-input" placeholder="搜尋商品" value="{{searchQuery}}">
@@ -61,37 +61,43 @@
       </div>
     </div>
   </div>
-</nav>
-<nav class="navbar navbar-light p-0" id="stickybar" style="display: none;">
-  <div class="container-fluid category-bar">
-    <ul class="nav mx-auto align-items-center">
-      <li class="nav-item">
-        <a class="nav-link py-3 {{#if isAllProducts}}active{{/if}}" href="/products">製品一覽</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link py-3 {{#ifEqual categoryQuery 'Figure'}}active{{/ifEqual}}" href="/products?category=Figure">Figure</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link py-3 {{#ifEqual categoryQuery '豆丁人'}}active{{/ifEqual}}" href="/products?category=豆丁人">豆丁人</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link py-3 {{#ifEqual categoryQuery 'Figma'}}active{{/ifEqual}}" href="/products?category=Figma">Figma</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link py-3 {{#ifEqual categoryQuery '組裝模型(仮)'}}active{{/ifEqual}}" href="/products?category=組裝模型(仮)">組裝模型(仮)</a>
-      </li>
-      <li class="nav-item">
-        <form class="px-3" action="/search" method="GET">
-          <div class="input-group">
-            <input type="text" name="q" class="form-control search-input" placeholder="搜尋商品" value="{{searchQuery}}">
-            <div class="input-group-append">
-              <button class="btn btn-orange">
-                <i class="fas fa-search px-2"></i>
-              </button>
+</header>
+{{!-- sticky --}}
+<nav id="stickybar" class="navbar navbar-light p-0" style="display: none;">
+  <div class="category-bar">
+    <div class="container">
+      <ul class="nav mx-auto align-items-center">
+        <li class="nav-item">
+          <a class="nav-link py-3 {{#if isAllProducts}}active{{/if}}" href="/products">製品一覽</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link py-3 {{#ifEqual categoryQuery 'Figure'}}active{{/ifEqual}}"
+            href="/products?category=Figure">Figure</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link py-3 {{#ifEqual categoryQuery '豆丁人'}}active{{/ifEqual}}" href="/products?category=豆丁人">豆丁人</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link py-3 {{#ifEqual categoryQuery 'Figma'}}active{{/ifEqual}}"
+            href="/products?category=Figma">Figma</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link py-3 {{#ifEqual categoryQuery '組裝模型(仮)'}}active{{/ifEqual}}"
+            href="/products?category=組裝模型(仮)">組裝模型(仮)</a>
+        </li>
+        <li class="nav-item">
+          <form class="px-3" action="/search" method="GET">
+            <div class="input-group">
+              <input type="text" name="q" class="form-control search-input" placeholder="搜尋商品" value="{{searchQuery}}">
+              <div class="input-group-append">
+                <button class="btn btn-orange">
+                  <i class="fas fa-search px-2"></i>
+                </button>
+              </div>
             </div>
-          </div>
-        </form>
-      </li>
-    </ul>
+          </form>
+        </li>
+      </ul>
+    </div>
   </div>
 </nav>

--- a/views/partials/signIn.hbs
+++ b/views/partials/signIn.hbs
@@ -1,5 +1,5 @@
-<section class="col-md-6 mb-2 py-3 px-1">
-  <div class="row panel mx-1">
+<section class="col-6">
+  <div class="row panel">
     <div class="panel-heading col-md-12">
       <div class="mt-3">已註冊的客戶</div>
     </div>

--- a/views/partials/signUp.hbs
+++ b/views/partials/signUp.hbs
@@ -1,5 +1,5 @@
-<section class="col-md-6 mb-2 py-3 px-1">
-  <div class="row panel mx-1">
+<section class="col-6">
+  <div class="row panel">
     <div class="panel-heading col-md-12">
       <div class="mt-3">初次使用的客戶</div>
     </div>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -92,8 +92,8 @@
     {{!-- 說明區塊 --}}
     <hr>
     <div class="row py-4">
-      <div class="col-md-2 font-weight-bold">商品介紹</div>
-      <div class="col-md-10">
+      <div class="col-2 font-weight-bold">商品介紹</div>
+      <div class="col-10">
         <p class="slogan">{{product.slogan}}</p>
         <p>{{product.description}}</p>
         <p class="mt-5">&copy; {{product.copyright}}</p>
@@ -102,8 +102,8 @@
     <hr>
     {{!-- 受理期間 --}}
     <div class="row py-4">
-      <div class="col-md-2 font-weight-bold">受理期間</div>
-      <div class="col-md-10">
+      <div class="col-2 font-weight-bold">受理期間</div>
+      <div class="col-10">
         {{#if product.isOnSale}}
           <s>【受注生產】{{product.releaseDateFormat}} 12:00 開始 {{product.deadlineFormat}} 21:00 結束。</s>
           <p>※ 無庫存時販售終止</p>
@@ -116,14 +116,14 @@
     {{!-- 特典 --}}
     {{#if product.hasGift}}
     <div class="row py-4">
-      <div class="col-md-2">
+      <div class="col-2">
         <span class="tag-icon icon2">附特典</span>
       </div>
-      <div class="col-md-6">
+      <div class="col-6">
         <p>【GREATSMILE ONLINE SHOP予約特典】</p>
         <p>「{{product.name}}」をご購入頂いた方に、「{{product.Gifts.0.name}}」をプレゼント！</p>
       </div>
-      <div class="col-md-4">
+      <div class="col-4">
         <div class="gift-img">
           <img class="w-100" src="{{product.Gifts.0.image}}" alt="gift-img">
         </div>
@@ -133,8 +133,8 @@
     {{/if}}
     {{!-- 價格、購物車 --}}
     <div class="row py-4">
-      <div class="col-md-2 font-weight-bold">價格</div>
-      <div class="col-md-6">
+      <div class="col-2 font-weight-bold">價格</div>
+      <div class="col-6">
         <small>NTD {{product.priceFormat}}</small>
         <div class="mt-2">
           <form id="addCart2" action="/cart" method="POST">
@@ -167,7 +167,7 @@
           </div>
         </div>
       </div>
-      <div class="col-md-4 buy-info">
+      <div class="col-4 buy-info">
         <p>※ おひとり様3つまでの販売となります。上限数を超えるご注文に関しましては、キャンセルさせていただきます。</p>
         <p>※ ご注文後のキャンセルにつきましては、一切お受け致しておりません。</p>
       </div>
@@ -175,8 +175,8 @@
     <hr>
     {{!-- 規格 --}}
     <div class="row py-4">
-      <div class="col-md-2 font-weight-bold">規格</div>
-      <div class="col-md-10">
+      <div class="col-2 font-weight-bold">規格</div>
+      <div class="col-10">
         <ul class="list-group">
           <li class="list-group-item">
             <span class="mr-5">商品名</span>

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -53,13 +53,13 @@
         {{!-- 分頁 --}}
         {{>pagination}}
         {{!-- 商品型錄 --}}
-        <div class="row">
+        <div class="row row-cols-5">
           {{#each getProducts}}
-            <div class="col-md-2-5 mb-3">
+            <div class="col px-2 mb-3">
               <div class="card">
                 <div class="card-body">
                   <div class="card-img-top card-bg mb-3">
-                    <img src="{{this.mainImg}}" class="card-img-top img-fit">
+                    <img src="{{this.mainImg}}" class="w-100">
                   </div>
                   {{#if hasInv}}
                     {{#if isPreorder}}
@@ -73,8 +73,8 @@
                   {{#if isGift}}
                     <span class="tag tag-gift">特典</span>
                   {{/if}}
-                  <h5 class="card-title mt-3">{{this.name}}</h5>
-                  <p class="card-text pt-3 d-flex justify-content-end">NTD {{this.priceFormat}}</p>
+                  <h5 class="card-title my-2 mb-4">{{this.name}}</h5>
+                  <p class="card-text d-flex justify-content-end">NTD {{this.priceFormat}}</p>
                 </div>
                 <div class="hover ">
                   <div class="icon-group">

--- a/views/profile.hbs
+++ b/views/profile.hbs
@@ -1,7 +1,7 @@
-<main class="container pt-2 pb-5">
-  <div class="row">
+<main class="container py-5">
+  <div class="row mb-5">
     {{!-- 主卡片 --}}
-    <section class="col-md-9 mb-5 p-3">
+    <section class="col-9 ">
       <div class="row panel mx-1">
         <div class="panel-heading col-md-12">
           <div class="mt-3">我的帳戶</div>
@@ -9,7 +9,7 @@
         {{!-- 內層卡片 --}}
         <div class="col-md-12 py-5">
           <div class="row">
-            <div class="panel-item col-md-5  py-2 mb-4 ml-5">
+            <div class="panel-item col-5  py-2 mb-4 ml-5">
               <div class="panel-item-heading col-md-12">
                 <div>設定檔</div>
               </div>
@@ -20,7 +20,7 @@
                 </ul>
               </div>
             </div>
-            <div class="panel-item col-md-5  py-2 mb-4 ml-4">
+            <div class="panel-item col-5  py-2 mb-4 ml-4">
               <div class="panel-item-heading col-md-12">
                 <div>通訊錄</div>
               </div>
@@ -30,7 +30,7 @@
                 </ul>
               </div>
             </div>
-            <div class="panel-item col-md-5  py-2 mb-4 ml-5">
+            <div class="panel-item col-5  py-2 mb-4 ml-5">
               <div class="panel-item-heading col-md-12">
                 <div>訂購紀錄</div>
               </div>
@@ -45,7 +45,7 @@
       </div>
     </section>
     {{!-- 側邊欄 --}}
-    <section class="col-md-3 mb-5 p-3">
+    <section class="col-3 ">
       <div class="row panel mx-1 side-box-shadow">
         <div class="panel-body w-100 p-3">
           <div>

--- a/views/sign.hbs
+++ b/views/sign.hbs
@@ -1,4 +1,4 @@
-<main class="container pt-2 pb-0">
+<main class="container py-5">
   <div class="row">
     {{#if isCheckout}}
       {{> signIn}}

--- a/views/success.hbs
+++ b/views/success.hbs
@@ -15,18 +15,18 @@
 
   <div class="row">
     {{!-- 主卡片 --}}
-    <section class="col-md-9 mb-5 p-3">
+    <section class="col-md-9 mb-md-5 p-3">
       <div class="row panel mx-1">
-        <div class="panel-heading col-md-12">
+        <div class="panel-heading col-12">
           <div>配送商品</div>
         </div>
         {{!-- 商品內容 --}}
-        <div class="panel-body col-md-12 py-3">
+        <div class="panel-body col-12 py-3">
           <div class="order-product">
             {{!-- 標題 --}}
             <div class="row">
-              <div class="col-md-7 item-title">商品</div>
-              <div class="col-md-5 item-title">
+              <div class="col-7 item-title">商品</div>
+              <div class="col-5 item-title">
                 <div class="d-flex justify-content-between align-items-center">
                   <span>商品價格</span>
                   <span>數量</span>
@@ -38,7 +38,7 @@
             {{!-- 內文 --}}
             {{#each data.cart.products}}
             <div class="row">
-              <div class="col-md-7 d-flex align-items-center h-100">
+              <div class="col-7 d-flex align-items-center h-100">
                 <div>
                   <a href="/products/{{this.id}}" class="product-img">
                     <img src="{{this.Images.0.url}}" class="img-fit">
@@ -53,7 +53,7 @@
                   {{/if}}
                 </div>
               </div>
-              <div class="col-md-5 font-format">
+              <div class="col-5 font-format">
                 <div class="d-flex justify-content-between align-items-center h-100 pb-2">
                   <span>NTD {{addDot this.price}}</span>
                   <span>{{addDot this.quantity}}</span>
@@ -68,8 +68,8 @@
           {{!-- 總計區塊 --}}
           <div class="order-amount">
             <div class="row">
-              <div class="col-md-7 font-format"></div>
-              <div class="col-md-5 font-format">
+              <div class="col-7 font-format"></div>
+              <div class="col-5 font-format">
                 <div class="d-flex justify-content-between align-items-center">
                   <span>小計</span>
                   <span>NTD {{addDot data.cart.subtotal}}</span>


### PR DESCRIPTION
<img src="https://i.gyazo.com/4a808d97e739c257330b909711bd486c.png" width=400>

使購物車，區分出「User車」與「 訪客車」。
並於登入時，合併訪客車商品，至 User 車。
登入後，會有合併提示，如上圖。

## 環境修改
**※ 記得刷新 migration**
- Cart model，追加欄位 `UserId` (資料庫為 `user_id`)
- passport 本地戰略，登入 function 優化
  - 調整為 `async / await` 格式
  - 反序列時，User 不 include 其他 table

## 確認項目
登入時，有分為 User 原本有車/無車，訪客有車/無車，排列組合共 4 種情況。
測試時，建議在 `app.js` 添加以下 console.log，檢視「當前購物車」與「user 登入狀態」。
並搭配資料庫檢查 Cart、CartItem。
<pre>
app.use((req, res, next) => {
  console.log('\n' + `${req.method} ${req.path}`)
  <b>console.log(`cartId`, req.session.cartId)  // add this</b>
  <b>console.log('user', req.user && req.user.id)  // add this</b>
  // 原本其他的 code...
}
</pre>

- 登入後，應該導入 `/cart`
  - 登入失敗時，仍舊可回到 `/users/signin` or `/users/signin/checkout`
  - User 車，原本有商品時，顯示商品合併提示 
- 登出後，會歸還購物車，console.log `cartId` 變為 undefined (session 被清除)

<br>

- 未登入時，將商品加入購物車，資料庫 Cart 的 `user_id` 應為 null

<br>

- 該 User 原本沒車
  - 登入時，訪客有車
    - 當前訪客車直接綁定給該 User，資料庫 `user_id` 應由 `null` 變為該 User id
  - 登入時，訪客無車
    - 直接登入，檢查 console.log `cartId` 應為無車狀態
    - 將任一商品加入購物車，查看資料庫，領到的車會被指派 `user_id`

<br>

- 該 User 原本有車
  - 登入時，訪客無車
    - 直接取得 User 車，console.log `cartId` 由 `undefined` 變為該 User 車之 id
  -  登入時，訪客有車 (最複雜) 
    - 登入前，先確認資料庫目前的 Cart 與 CartItem
    - 登入後，訪客車商品，合併到 User 車
      - 檢查資料庫，訪客車與相關 CartItem 應被移除
      - User 車，應多出原本訪客車的商品
      - 重複之商品，直接追加數量
        - 數量不會超過 3 筆
        - 如該商品庫存僅剩 2，數量應不超過 2

合併規則參考
<img src="https://i.gyazo.com/d79d23796e88e5098074472c5401272a.png" width=400>

ps. 如果未來有PM提出要合併購物車的要求，請說服他說不要，太難做了。