### PR TITLE
【加入】訂單成功頁加入立即付款按鈕

### DIFF
--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -251,6 +251,7 @@ module.exports = {
       })
       
       // 傳遞資料給 success 頁
+      passData.id = order.id
       passData.sn = sn
       passData.createdAt = order.createdAt
       req.flash('passData', passData)

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -24,11 +24,11 @@
                   <table>
                     <tbody>
                       <tr>
-                        <td class="accordion-thead">{{this.sn}}
-                          {{#if this.payStatus}}
-                          {{else}}
-                          <small class="text-danger font-weight-bold d-block">(未付款)</small>
-                          {{/if}}
+                        <td class="accordion-thead">
+                          <span>{{this.sn}}</span>
+                          {{#unless this.payStatus}}
+                            <small class="text-danger font-weight-bold d-block">(未付款)</small>
+                          {{/unless}}
                         </td>
                         <td class="accordion-thead">{{this.createdTime}}</td>
                         <td class="accordion-thead">NTD {{addDot this.amount}}</td>

--- a/views/orders.hbs
+++ b/views/orders.hbs
@@ -24,7 +24,12 @@
                   <table>
                     <tbody>
                       <tr>
-                        <td class="accordion-thead">{{this.sn}}</td>
+                        <td class="accordion-thead">{{this.sn}}
+                          {{#if this.payStatus}}
+                          {{else}}
+                          <small class="text-danger font-weight-bold d-block">(未付款)</small>
+                          {{/if}}
+                        </td>
                         <td class="accordion-thead">{{this.createdTime}}</td>
                         <td class="accordion-thead">NTD {{addDot this.amount}}</td>
                       </tr>

--- a/views/success.hbs
+++ b/views/success.hbs
@@ -7,7 +7,8 @@
           <h4 class="pb-4">訂單處理中，謝謝您的光顧。</h4>
           <p>訂單內容已發送至 {{user.email}}，訂單編號為 {{data.sn}}。</p>
           <p class="pb-5">下訂日期 {{orderDate}}</p>
-          <a href="/products" class="btn px-4">繼續購物</a>
+          <a href="/products" class="btn px-4 mx-1">繼續購物</a>
+          <a href="/orders/{{data.id}}/payment" class="btn px-4 mx-1">立即付款</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
![2](https://user-images.githubusercontent.com/50958992/72371027-7180fc00-373e-11ea-85b5-de73f302f6c2.png)
## 確認目標
- 訂單成功頁會有 `繼續購物` `立即付款` 的按鈕
- 點選 `立即付款` 會被導到藍新結帳頁
- 使用者訂單頁可以直接看到訂單是否付款

![1](https://user-images.githubusercontent.com/50958992/72371026-7180fc00-373e-11ea-90f5-31151d302ef9.png)

