### PR TITLE
【加入】後台， 商品預覽

### DIFF
--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -48,6 +48,42 @@ module.exports = {
     }
   },
 
+  getProduct: async (req, res) => {
+    try {
+      const product = await Product.findOne({
+        where: { id: +req.params.id },
+        include: ['Gifts', 'Images', 'tags', 'Series', 'Category'],
+        // 使 Images 第一張為 mainImg，之後依上傳順排序
+        order: [
+          ['Images', 'isMain', 'DESC'],
+          ['Images', 'id', 'ASC']
+        ]
+      })
+
+      if (!product) return res.redirect('/products')
+
+      // 頁面所需 data
+      product.priceFormat = product.price.toLocaleString()
+      product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
+      product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')
+      product.deadlineFormat = moment(product.deadline).format('YYYY年MM月DD日(dd)')
+      product.hasGift = (product.Gifts.length !== 0) ? true : false
+      product.isOnSale = moment(new Date).isAfter(product.deadline)
+      product.hasInv = (product.inventory !== 0)
+      product.category = product.Category.name
+
+      res.render('product', {
+        css: 'product', js: 'product', layout: 'main',
+        useSlick: true, useLightbox: true,
+        product
+      })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  },
+
   getAddPage: async (req, res) => {
     try {
       const [categories, series, tag] = await Promise.all([

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -359,6 +359,8 @@ module.exports = {
       const image = await Image.findByPk(req.params.id)
       const redirectUrl = `/admin/products/${image.ProductId}/edit`
       await image.destroy()
+
+      req.flash('success', '圖片刪除成功！')
       res.redirect(redirectUrl)
 
     } catch (err) {

--- a/public/css/product.css
+++ b/public/css/product.css
@@ -21,7 +21,6 @@ section {
 /* 圖片畫廊 */
 .gallery-main {
   width: 530px;
-  height: 670px;
   margin: 0 auto;
   background: #eee;
 }
@@ -31,9 +30,17 @@ section {
   margin: 0 auto;
 }
 
+.gallery-nav .img-thumbnail {
+  display: flex;
+  align-items: center;
+  width: 74px;
+  height: 74px;
+  padding: 0;
+}
+
 .gallery-nav img {
-  width: 70px;
-  height: 70px; 
+  height: 70px;
+  margin: 0 auto;
 }
 
 .slick-prev {
@@ -44,12 +51,13 @@ section {
   right: -37px;
 }
 
+.slick-slide:focus,
 .slick-slide a:focus {
   outline: none
 }
 
-.gallery-nav .slick-current img {
-  border: 3px solid #ff9600;
+.gallery-nav .slick-current .img-thumbnail {
+  border: 2px solid #ff9600;
 }
 
 .slick-prev:before, .slick-next:before {

--- a/routes/admin/products.js
+++ b/routes/admin/products.js
@@ -9,6 +9,7 @@ const upload = multer({ dest: 'temp/' })
 router.get('/', prodCtrller.getProducts)
 router.get('/new', prodCtrller.getAddPage)
 router.get('/:id/edit', prodCtrller.getEditPage)
+router.get('/:id/preview', prodCtrller.getProduct)
 
 router.post('/', upload.array('image', 10), prodCtrller.postNewProduct)
 router.post('/:id/display', prodCtrller.postDisplay)

--- a/views/admin/edit.hbs
+++ b/views/admin/edit.hbs
@@ -137,11 +137,11 @@
                 <label for="image">
                   <i class="fas fa-upload btn btn-light mt-2 py-2"></i>
                 </label>
-                <input type="file" name="image" multiple="multiple" id="image" hidden>
+                <input type="file" name="image" multiple="multiple" id="image" form="editForm" hidden>
               </div>
               <div id="images" class="form-check form-check-inline mr-0 pl-2 col-10 d-flex flex-wrap"></div>
               <small id="emailHelp" class="form-text text-muted ml-3">
-                <span>＊ 預設第一張為商品「主圖片」，規格大小為 570x670 px</span>
+                <span>＊ 規格大小為 570x670 px</span>
               </small>
             </div>
           </div>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -20,13 +20,13 @@
           <tr>
             <td>{{this.id}}</td>
             <td>
-              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+              <a href="/admin/products/{{this.id}}/preview" target="_blank" class="text-decoration-none text-dark d-block">
                 <img src="{{this.mainImg}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
                   style="height:50px">
               </a>
             </td>
             <td>
-              <a href="/products/{{this.id}}" target="_blank" class="text-decoration-none text-dark d-block">
+              <a href="/admin/products/{{this.id}}/preview" target="_blank" class="text-decoration-none text-dark d-block">
                 {{this.name}}
               </a>
             </td>

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -23,8 +23,8 @@
         <ul class="gallery-nav mt-4">
           {{#each product.Images}}
             <li>
-              <a href="jquery:;">
-                <img src="{{url}}" alt="product-image-sm" class="img-thumbnail">
+              <a href="jquery:;" class="img-thumbnail">
+                <img src="{{url}}" alt="product-image-sm">
               </a>
             </li>
           {{/each}}


### PR DESCRIPTION
原本後台商品，可點擊圖片 or 名稱，連結到前台「商品詳細」檢視結果。
但前台商品詳細，有阻擋「未上架」商品檢視，導致管理員新增商品，上架前無法檢查最終結果。

故，加開路由 `/admin/products/:id/preview`，
使後台能預覽商品的最終結果。 (方式為，開新視窗)

## 確認目標
- 後台商品，點擊未上架商品之圖片 or 名稱，可以在新視窗預覽前台顯示效果
- 前台畫廊優化
  - 如上傳了非 530x670 比例的圖片，應不會產生明顯爆版
  - 畫廊下方縮圖，現在可顯示為原圖之長方形比例，而外框仍維持正方形 (圖片不會被壓縮)

<img src="https://i.gyazo.com/68a50641d69f4d8b34f17396f0ee4846.png" width=500>