### PR TITLE
【加入】後台特典關聯商品之功能

### DIFF
--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -73,14 +73,16 @@ module.exports = {
           input.image = (await imgur.uploadFile(file.path)).data.link
         }
 
-        if (!input.ProductId) {
-          input.ProductId = null
+        if (input.ProductId.trim() != '') {
+          const product = await Product.findByPk(input.ProductId)
+          if (!product) {
+            req.flash('error', '欲關聯商品不存在！')
+            return res.redirect('back')
+          }
         }
 
-        const product = await Product.findByPk(input.ProductId)
-        if (!product) {
-          req.flash('error', '欲關聯商品不存在！')
-          return res.redirect('back')
+        if (input.ProductId.trim() === '') {
+          input.ProductId = null
         }
 
         const id = +req.params.giftsid

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -1,5 +1,5 @@
 const db = require('../../models')
-const { Gift } = db
+const { Gift, Product } = db
 
 const imgur = require('imgur')
 const IMGUR_CLIENT_ID = process.env.IMGUR_CLIENT_ID
@@ -75,6 +75,12 @@ module.exports = {
 
         if (!input.ProductId) {
           input.ProductId = null
+        }
+
+        const product = await Product.findByPk(input.ProductId)
+        if (!product) {
+          req.flash('error', '欲關聯商品不存在！')
+          return res.redirect('back')
         }
 
         const id = +req.params.giftsid

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -60,38 +60,45 @@ module.exports = {
   putGift: async (req, res) => {
     try {
       const input = { ...req.body }
+      const giftId = +req.params.giftsid
       if (input.name.trim() === '') {
-
         req.flash('error', '特典名稱不能為空白')
-        res.redirect('back')
-
-      } else {
-
-        const { file } = req
-      
-        if (file) {
-          input.image = (await imgur.uploadFile(file.path)).data.link
-        }
-
-        if (input.ProductId.trim() != '') {
-          const product = await Product.findByPk(input.ProductId)
-          if (!product) {
-            req.flash('error', '欲關聯商品不存在！')
-            return res.redirect('back')
-          }
-        }
-
-        if (input.ProductId.trim() === '') {
-          input.ProductId = null
-        }
-
-        const id = +req.params.giftsid
-        await Gift.update(input, { where: { id } })
-
-        req.flash('success', '更新成功！')
-        res.redirect('/admin/gifts')
-
+        return res.redirect('back')
       }
+
+      // 處理圖片
+      const { file } = req
+      if (file) {
+        input.image = (await imgur.uploadFile(file.path)).data.link
+      }
+
+      // 處理關聯商品
+      if (input.ProductId.trim() !== '') {
+        const product = await Product.findByPk(input.ProductId, {
+          attributes: [ 'id' ],
+          include: Gift
+        })
+
+        if (!product) {
+          req.flash('error', '欲關聯商品不存在！')
+          return res.redirect('back')
+        }
+
+        const gift = product.Gifts[0]
+        if (gift && (gift.id !== giftId)) {
+          req.flash('error', `該商品已有特典 id ${gift.id}`)
+          return res.redirect('back')
+        }
+      }
+
+      if (input.ProductId.trim() === '') {
+        input.ProductId = null
+      }
+
+      await Gift.update(input, { where: { id: giftId } })
+
+      req.flash('success', '更新成功！')
+      res.redirect('/admin/gifts')
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/giftCtrller.js
+++ b/controllers/admin/giftCtrller.js
@@ -42,7 +42,7 @@ module.exports = {
       if (file) {
         input.image = (await imgur.uploadFile(file.path)).data.link
       }
-
+  
       const maxId = await Gift.max('id')
       await Gift.create({ id: maxId + 1, ...input })
 
@@ -71,6 +71,10 @@ module.exports = {
       
         if (file) {
           input.image = (await imgur.uploadFile(file.path)).data.link
+        }
+
+        if (!input.ProductId) {
+          input.ProductId = null
         }
 
         const id = +req.params.giftsid

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -5,6 +5,9 @@
         <div class="alertBlock mb-2">
           {{> alert}}
         </div>
+        <div  class="text-right">
+          <small class="form-text text-muted">※ 可透過編輯特典，設定關聯之商品</small>
+        </div>
         <form class="form-inline d-flex justify-content-end" action="/admin/gifts" method="POST" enctype="multipart/form-data" id="newGift">
           <div class="d-flex align-items-center justify-content-center">
             <img class="rounded mx-auto d-block" id="preview_img" name="preview_img" src="" style="height:40px">
@@ -97,6 +100,9 @@
                             value='{{this.name}}' required>
                           <input type="number" class="form-control input-center mt-1" name="ProductId"
                             value='{{this.ProductId}}' placeholder="輸入關聯商品號碼">
+                          <div class="text-center">
+                            <small class="form-text text-muted">※ 商品ID欄位空白，可移除關聯</small>
+                          </div>
                         </div>
                       </form>
                     </div>

--- a/views/admin/gifts.hbs
+++ b/views/admin/gifts.hbs
@@ -9,7 +9,7 @@
           <div class="d-flex align-items-center justify-content-center">
             <img class="rounded mx-auto d-block" id="preview_img" name="preview_img" src="" style="height:40px">
             <label for="image">
-                <i class="fas fa-upload btn btn-light ml-2 mb-1 py-2"></i>
+              <i class="fas fa-upload btn btn-light ml-2 mb-1 py-2"></i>
             </label>
             <input hidden type="file" id="image" name="image" form="newGift">
           </div>
@@ -87,7 +87,6 @@
                     <div class="collapse row" id="collapse_{{this.id}}" data-parent="#accordionEdit">
                       <input hidden type="file" class="inputImg" id="imageEdit_{{this.id}}" name="image" form="edit_{{this.id}}">
                       <img class="rounded mx-auto d-block editImg" src="" style="height:50px">
-
                     </div>
                   </td>
                   <td class="p-0">
@@ -96,6 +95,8 @@
                         <div class="form-group mx-sm-3 mb-2 mt-1">
                           <input type="text" class="form-control input-center" name="name" placeholder="輸入特典名稱..."
                             value='{{this.name}}' required>
+                          <input type="number" class="form-control input-center mt-1" name="ProductId"
+                            value='{{this.ProductId}}' placeholder="輸入關聯商品號碼">
                         </div>
                       </form>
                     </div>


### PR DESCRIPTION
<img width="593" alt="螢幕快照 2020-01-17 下午1 56 56" src="https://user-images.githubusercontent.com/49901777/72587789-3e528e80-3931-11ea-935c-25d8df2f42b3.png">

## PR內容
- 後台特典頁面，編輯特典時可以加入關聯的商品id

## 手動驗證
- 新增一筆特典，展開其編輯欄位後會顯示空白的商品欄位
- 商品欄位可以寫入商品id並更新
- 商品欄位若清空並更新，會將該特典的productId清空為null
- 若寫入的商品id不存在，後端會阻擋寫入並回傳提示