### PR TITLE
【debug】防止 checkout 時跳過表單

### DIFF
--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -239,7 +239,7 @@ module.exports = {
       // 取出 data 並 format
       const data = { ...passData }
       data.address = data.address.join(',')
-      data.receiver = data.receiver.join(',')
+      data.receiver = data.receiver.join(' ')
 
       // 建立 Order
       const order = await Order.create({

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -90,7 +90,7 @@ module.exports = {
       req.flash('passData', data)
 
       // 建立已通過 flag
-      req.flash('passedStep', [0])
+      req.flash('passedSteps', [0])
 
       res.redirect('checkout_1')
 
@@ -103,26 +103,19 @@ module.exports = {
   getCheckout(req, res) {
     try {
       const data = req.flash('passData')[0]
-
       const beforePath = req.flash('beforePath')
-      console.log('beforePath', beforePath)
-
+      
       // 無 passData，阻擋退回
       if (!data) return res.redirect('/cart')
       req.flash('passData', data)
 
-      // 審核是否有經過 POST
-      const passedStep = req.flash('passedStep')
-      console.log('passedStep', passedStep)
-      req.flash('passedStep', passedStep)
+      // 審核是否有經過 POST 表單
+      const passedSteps = req.flash('passedSteps')
+      req.flash('passedSteps', passedSteps)
 
-      const beforeStep = +req.path.slice(-1)
-      console.log('beforeStep', beforeStep)
-      const isPassed = passedStep.includes(beforeStep - 1)
-      if (!isPassed) {
-        console.log('!isPassed')
-        return res.redirect('/orders' + beforePath)
-      }
+      const beforeStep = (+req.path.slice(-1)) - 1
+      const isPassed = passedSteps.includes(beforeStep)
+      if (!isPassed) return res.redirect('/orders' + beforePath)
 
       req.flash('beforePath', [req.path])
 
@@ -158,7 +151,7 @@ module.exports = {
       req.flash('passData', data)
 
       // 建立已通過 flag
-      req.flash('passedStep', 1)
+      req.flash('passedSteps', 1)
 
       res.redirect('checkout_2')
 
@@ -192,7 +185,7 @@ module.exports = {
       req.flash('passData', data)
 
       // 建立已通過 flag
-      req.flash('passedStep', 2)
+      req.flash('passedSteps', 2)
 
       res.redirect('checkout_3')
 
@@ -216,7 +209,7 @@ module.exports = {
       req.flash('passData', data)
 
       // 建立已通過 flag
-      req.flash('passedStep', 3)
+      req.flash('passedSteps', 3)
 
       res.redirect('checkout_4')
 
@@ -235,9 +228,9 @@ module.exports = {
         return res.redirect('/cart')
       }
 
-      // 確認已通過各表單 passedStep
-      const passedStep = req.flash('passedStep')
-      const isPassed = [0, 1, 2, 3].every(step => passedStep.includes(step))
+      // 確認已通過各表單 passedSteps
+      const passedSteps = req.flash('passedSteps')
+      const isPassed = [0, 1, 2, 3].every(step => passedSteps.includes(step))
       if (!isPassed) {
         req.flash('error', '錯誤訪問')
         return res.redirect('/cart')

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -228,8 +228,17 @@ module.exports = {
 
   async postOrder(req, res) {
     try {
+      // 確認攜帶 passData
       const passData = req.flash('passData')[0]
       if (!passData) {
+        req.flash('error', '錯誤訪問')
+        return res.redirect('/cart')
+      }
+
+      // 確認已通過各表單 passedStep
+      const passedStep = req.flash('passedStep')
+      const isPassed = [0, 1, 2, 3].every(step => passedStep.includes(step))
+      if (!isPassed) {
         req.flash('error', '錯誤訪問')
         return res.redirect('/cart')
       }

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -89,6 +89,9 @@ module.exports = {
       req.flash('passData')  // reset flash
       req.flash('passData', data)
 
+      // 建立已通過 flag
+      req.flash('passedStep', [0])
+
       res.redirect('checkout_1')
 
     } catch (err) {
@@ -101,9 +104,27 @@ module.exports = {
     try {
       const data = req.flash('passData')[0]
 
+      const beforePath = req.flash('beforePath')
+      console.log('beforePath', beforePath)
+
       // 無 passData，阻擋退回
       if (!data) return res.redirect('/cart')
       req.flash('passData', data)
+
+      // 審核是否有經過 POST
+      const passedStep = req.flash('passedStep')
+      console.log('passedStep', passedStep)
+      req.flash('passedStep', passedStep)
+
+      const beforeStep = +req.path.slice(-1)
+      console.log('beforeStep', beforeStep)
+      const isPassed = passedStep.includes(beforeStep - 1)
+      if (!isPassed) {
+        console.log('!isPassed')
+        return res.redirect('/orders' + beforePath)
+      }
+
+      req.flash('beforePath', [req.path])
 
       const view = req.path.slice(1)
       res.render(view, { css: 'checkout', js: 'checkout', data, view })
@@ -136,6 +157,9 @@ module.exports = {
       const data = { ...req.flash('passData')[0], ...receiver }
       req.flash('passData', data)
 
+      // 建立已通過 flag
+      req.flash('passedStep', 1)
+
       res.redirect('checkout_2')
 
     } catch (err) {
@@ -167,6 +191,9 @@ module.exports = {
       data.amount = (data.cart.subtotal + input.shipping)
       req.flash('passData', data)
 
+      // 建立已通過 flag
+      req.flash('passedStep', 2)
+
       res.redirect('checkout_3')
 
     } catch (err) {
@@ -187,6 +214,9 @@ module.exports = {
       // 付款方式注入 passData
       const data = { ...req.flash('passData')[0], ...input}
       req.flash('passData', data)
+
+      // 建立已通過 flag
+      req.flash('passedStep', 3)
 
       res.redirect('checkout_4')
 


### PR DESCRIPTION
結帳 checkout 時，防止使用者跳過表單，直接進行提交。
順便修改建立訂單時，儲存的收件人姓 + 名格式，由「逗號」改為空一格。

<img src="https://i.gyazo.com/178cfc84cd24ee8ad1b13b8f81428157.png" width=400>

## 確認目標
- 從 `/cart` 開始結帳後，無法直接網址輸入 `GET /orders/checkout_4` 等，進入後面表單
  - 只能經過正規途徑，POST 表單，才能進入下一頁
  - 不當訪問後，可以導回原本的頁面繼續進行，checkout 系統應不會壞掉

<br>

- 未填寫完所有表單時，應無法 `POST /orders`
  - 會被導回購物車頁，並顯示「錯誤訪問」

測試方法，在 checkout 途中的頁面，從瀏覽器輸入已下指令進行 POST。
```
$.post('/orders', function (data) {
  document
    .open('text/html', 'replace')
    .write(data)
})
```

- 訂單成立後，收件人姓名應為 `姓氏 名`，中間空一格，而非逗號