### PR TITLE
【加入】前台 tag 關聯資料庫

### DIFF
--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -43,11 +43,13 @@ module.exports = {
 
       // tag
       const tagQuery = req.query.tag || '所有商品'
-      const tagId = {
-        '預購中商品一覽': 1,
-        '附特典': 2,
-        '庫存販售商品': 3,
-      }
+      const tagId = {}
+      const tagGroup = res.locals.tagGroup
+      tagGroup.forEach(item => {
+        const key = item.name
+        const val = item.id
+        tagId[key] = val
+      })
 
       if (tagQuery) {
         if (tagQuery == '即將截止預購') {

--- a/middleware/tag.js
+++ b/middleware/tag.js
@@ -1,0 +1,18 @@
+const db = require('../models')
+const Tag = db.Tag
+
+module.exports = {
+  // 取得 tag 名稱
+  getTagGroup: async (req, res, next) => {
+    try {
+      const tagGroup = await Tag.findAll({ attributes: ['id', 'name'] })
+      res.locals.tagGroup = tagGroup
+
+      next()
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  }
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,16 +6,18 @@ const { getCartItem } = require('../middleware/cart.js')
 const { isAuth } = require('../middleware/auth.js')
 const { newebpayCb } = require('../controllers/orderCtrller.js')
 
+const { getTagGroup } = require('../middleware/tag.js')
+
 module.exports = app => {
   app.use('/admin', require('./admin/index.js'))
   app.post('/newebpay/callback', newebpayCb)  // 金流API callback
   
   app.use('/', getCartItem)  // 請勿更動順序
-  app.use('/products', require('./products.js'))
+  app.use('/products', getTagGroup, require('./products.js'))
   app.use('/cart', require('./cart.js'))
   app.use('/orders', isAuth, require('./orders.js'))
   app.use('/users', require('./users.js'))
 
   app.get('/', (req, res) => res.render('home'))
-  app.get('/search', require('../controllers/prodCtrller').getProducts)
+  app.get('/search', getTagGroup, require('../controllers/prodCtrller').getProducts)
 }

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -13,15 +13,11 @@
             <li class="d-inline">
               <a class="btn btn-sm {{#ifEqual tagQuery '所有商品'}}active{{/ifEqual}}" data-tag="所有商品">所有商品</a>
             </li>
-            <li class="d-inline">
-              <a class="btn btn-sm {{#ifEqual tagQuery '預購中商品一覽'}}active{{/ifEqual}}" data-tag="預購中商品一覽">預購中商品一覽</a>
-            </li>
-            <li class="d-inline">
-              <a class="btn btn-sm {{#ifEqual tagQuery '附特典'}}active{{/ifEqual}}" data-tag="附特典">附特典</a>
-            </li>
-            <li class="d-inline">
-              <a class="btn btn-sm {{#ifEqual tagQuery '庫存販售商品'}}active{{/ifEqual}}" data-tag="庫存販售商品">庫存販售商品</a>
-            </li>
+            {{#each tagGroup}}
+              <li class="d-inline">
+                <a class="btn btn-sm {{#ifEqual ../tagQuery this.name}}active{{/ifEqual}}" data-tag="{{this.name}}">{{this.name}}</a>
+              </li>
+            {{/each}}
             <li class="d-inline">
               <a class="btn btn-sm {{#ifEqual tagQuery '即將截止預購'}}active{{/ifEqual}}" data-tag="即將截止預購">即將截止預購</a>
             </li>


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/50958992/72615384-87c1ce80-396f-11ea-870a-afaa0e77863a.png)

- 前台 Tag 與資料庫建立關聯
  - 除了 `所有商品`  和 `即將截止預購` 是綁死的，其他都為自動帶入
- 建立 tag 的中間件 `/middleware /tag.js`
- /products、/search 兩個路由引入中間件

## 確認目標
- /products 路由
- /search 路由

以上兩個路由都應可顯示標籤，新增標籤時也應能成功帶入。 

