### PR TITLE
【重構】前台 getProducts

### DIFF
--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -24,16 +24,19 @@ function setWhere(req, where) {
 
   // 製作 tag where (tagQuery 非數字者為特規)
   let tagQuery = req.query.tag || '所有商品'
-  if (!isNaN(tagQuery)) { tagQuery = +tagQuery }
-  if (tagQuery !== '所有商品') {
-    if (tagQuery !== '即將截止預購') return where['$tags.id$'] = tagQuery
+  const isNumber = !isNaN(tagQuery)
+  if (isNumber) {
+    tagQuery = +tagQuery
+    where['$tags.id$'] = tagQuery
+  }
 
+  if (tagQuery === '即將截止預購') {
     // 從 Date.now 往後取 7 天快截止的商品
     const date = moment().add(7, 'days').endOf('day')
 
     where['$tags.id$'] = 1  // 預購中
     where.deadline = { [Op.lte]: date }
-  } 
+  }
 
   return { categoryQuery, searchQuery, tagQuery }
 }

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -1,66 +1,11 @@
 const db = require('../models')
-const { Product, Image, Gift, Category } = db
+const { Product, Image, Gift } = db
 
-const Op = require('sequelize').Op
 const moment = require('moment')
 moment.locale('zh-tw')
 
 const PAGE_LIMIT = 30
-const { genQueryString } = require('../lib/tools.js')
-
-function setWhere(req, where) {
-  // 製作 category where
-  let categoryQuery = +req.query.category || 0
-  if (categoryQuery) { where.CategoryId = categoryQuery }
-
-  // 製作 search where (商品名 or 作品名)
-  const searchQuery = req.query.q
-  if (searchQuery) {
-    where[Op.or] = {
-      name: { [Op.like]: `%${searchQuery}%` },
-      '$Series.name$': { [Op.like]: `%${searchQuery}%` }
-    }
-
-    categoryQuery = null  // 搜尋時，關閉分類 active 特效
-  }
-
-  // 製作 tag where (tagQuery 非數字者為特規)
-  let tagQuery = req.query.tag || '所有商品'
-  const isNumber = !isNaN(tagQuery)
-  if (isNumber) {
-    tagQuery = +tagQuery
-    where['$tags.id$'] = tagQuery
-  }
-
-  if (tagQuery === '即將截止預購') {
-    // 從 Date.now 往後取 7 天快截止的商品
-    const date = moment().add(7, 'days').endOf('day')
-
-    where['$tags.id$'] = 1  // 預購中
-    where.deadline = { [Op.lte]: date }
-  }
-
-  return { categoryQuery, searchQuery, tagQuery }
-}
-
-function getPagination(result, PAGE_LIMIT, page) {
-  const totalPages = Math.ceil(result.count / PAGE_LIMIT)
-  const pagesArray = Array.from({ length: totalPages }, (val, index) => index + 1)
-  const prev = (page === 1) ? 1 : page - 1
-  const next = (page === totalPages) ? totalPages : page + 1
-
-  return { pagesArray, prev, next } 
-}
-
-function getBread(categoryQuery, req, res) {
-  if (categoryQuery) {
-    const categories = res.locals.categoryBar
-    const category = categories.find(cate => cate.id === categoryQuery)
-    return category.name
-  }
-
-  if (req.path.includes('search')) return '搜尋商品'
-}
+const { genQueryString, setWhere, getPagination, getBread } = require('../lib/product_tools.js')
 
 module.exports = {
   getProducts: async (req, res) => {
@@ -112,9 +57,10 @@ module.exports = {
       const bread = getBread(categoryQuery, req, res) || '製品一覽'
 
       res.render('products', {
-        js: 'products',
-        css: 'products',
-        getProducts, selectedSort, searchQuery, bread, pagesArray, queryString, categoryQuery, tagQuery, page, prev, next
+        css: 'products', js: 'products', 
+        getProducts, bread,
+        categoryQuery, searchQuery, tagQuery, selectedSort,
+        pagesArray, page, prev, next, queryString
       })
 
     } catch (err) {

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -8,6 +8,16 @@ moment.locale('zh-tw')
 const pageLimit = 30
 const { genQueryString } = require('../lib/tools.js')
 
+function setTagWhere(tagQuery, where) {
+  if (tagQuery !== '即將截止預購') return where['$tags.id$'] = tagQuery
+
+  // 從 Date.now 往後取 7 天快截止的商品
+  const today = moment().add(7, 'days').endOf('day')
+
+  where['$tags.id$'] = 1  // 預購中
+  where.deadline = { [Op.lte]: today }
+}
+
 module.exports = {
   getProducts: async (req, res) => {
     try {
@@ -31,26 +41,11 @@ module.exports = {
         } 
       }
 
-      // tag
+      // 製作 tag where (tagQuery 非數字者為特規)
       let tagQuery = req.query.tag || '所有商品'
       if (!isNaN(tagQuery)) { tagQuery = +tagQuery }
-
-      if (tagQuery === '即將截止預購') {
-        // 取得當地今日 23:99 ，再轉回時間格式
-        // 從今天往後取 7 天快截止的商品
-        const today = moment().add(7, 'days').endOf('day')
-        const todayDate = new Date(today)
-
-        where['$tags.id$'] = 1  // 預購中
-        where.deadline = {      
-          [Op.lte]: todayDate}
-
-      } else if (tagQuery === '所有商品') {
-        // 什麼都不加
-      } else {
-        where['$tags.id$'] = tagQuery
-      }
-
+      if (tagQuery !== '所有商品') { setTagWhere(tagQuery, where) }
+      
       // 設定分頁偏移
       const page = +req.query.page || 1
       const offset = (page - 1) * pageLimit 

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -5,7 +5,7 @@ const Op = require('sequelize').Op
 const moment = require('moment')
 moment.locale('zh-tw')
 
-const pageLimit = 30
+const PAGE_LIMIT = 30
 const { genQueryString } = require('../lib/tools.js')
 
 function setWhere(req, where) {
@@ -43,8 +43,8 @@ function setWhere(req, where) {
   return { categoryQuery, searchQuery, tagQuery }
 }
 
-function getPagination(result, pageLimit, page) {
-  const totalPages = Math.ceil(result.count / pageLimit)
+function getPagination(result, PAGE_LIMIT, page) {
+  const totalPages = Math.ceil(result.count / PAGE_LIMIT)
   const pagesArray = Array.from({ length: totalPages }, (val, index) => index + 1)
   const prev = (page === 1) ? 1 : page - 1
   const next = (page === totalPages) ? totalPages : page + 1
@@ -90,12 +90,12 @@ module.exports = {
 
       // 設定分頁偏移
       const page = +req.query.page || 1
-      const offset = (page - 1) * pageLimit
+      const offset = (page - 1) * PAGE_LIMIT
 
       // 製作頁面資料
       const today = new Date()
       const products = result.rows
-      const getProducts = products.slice(offset, offset + pageLimit)
+      const getProducts = products.slice(offset, offset + PAGE_LIMIT)
       getProducts.forEach(product => {
         product.mainImg = product.Images.find(img => img.isMain).url
         product.priceFormat = product.price.toLocaleString()
@@ -105,7 +105,7 @@ module.exports = {
       })
 
       // 製作 pagination bar 資料、超連結位址
-      const { pagesArray, prev, next } = getPagination(result, pageLimit, page)
+      const { pagesArray, prev, next } = getPagination(result, PAGE_LIMIT, page)
       const queryString = genQueryString(req.query)
 
       // 製作麵包屑

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -47,6 +47,16 @@ function getPagination(result, pageLimit, page) {
   return { pagesArray, prev, next } 
 }
 
+function getBread(categoryQuery, req, res) {
+  if (categoryQuery) {
+    const categories = res.locals.categoryBar
+    const category = categories.find(cate => cate.id === categoryQuery)
+    return category.name
+  }
+
+  if (req.path.includes('search')) return '搜尋商品'
+}
+
 module.exports = {
   getProducts: async (req, res) => {
     try {
@@ -54,6 +64,7 @@ module.exports = {
       const sort = req.query.sort || 'releaseDate'
       const orderBy = req.query.order || 'DESC'
       const order = [[sort, orderBy]]
+      const selectedSort = `${sort},${orderBy}`
 
       // 製作 db where 物件
       const where = { status: 1 }
@@ -92,14 +103,8 @@ module.exports = {
       const { pagesArray, prev, next } = getPagination(result, pageLimit, page)
       const queryString = genQueryString(req.query)
 
-      const selectedSort = `${sort},${orderBy}`
-      let bread = '製品一覽'
-      if (categoryQuery) { 
-        const categories = res.locals.categoryBar
-        const category = categories.find(cate => cate.id === categoryQuery)
-        bread = category.name 
-      }
-      if (req.path.includes('search')) { bread ='搜尋商品'}
+      // 製作麵包屑
+      const bread = getBread(categoryQuery, req, res) || '製品一覽'
 
       // 當為所有商品頁的 製品一覽 時為 true 
       // search 時，取消分類 active 特效

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -38,6 +38,15 @@ function setWhere(req, where) {
   return { categoryQuery, searchQuery, tagQuery }
 }
 
+function getPagination(result, pageLimit, page) {
+  const totalPages = Math.ceil(result.count / pageLimit)
+  const pagesArray = Array.from({ length: totalPages }, (val, index) => index + 1)
+  const prev = (page === 1) ? 1 : page - 1
+  const next = (page === totalPages) ? totalPages : page + 1
+
+  return { pagesArray, prev, next } 
+}
+
 module.exports = {
   getProducts: async (req, res) => {
     try {
@@ -79,13 +88,8 @@ module.exports = {
         product.hasInv = (product.inventory !== 0)
       })
 
-      // 製作 pagination bar 資料
-      const totalPages = Math.ceil(result.count / pageLimit)
-      const pagesArray = Array.from({ length: totalPages }, (val, index) => index + 1)
-      const prev = (page === 1) ? 1 : page - 1
-      const next = (page === totalPages) ? totalPages : page + 1
-
-      // 生成 pagination bar 超連結位址
+      // 製作 pagination bar 資料、超連結位址
+      const { pagesArray, prev, next } = getPagination(result, pageLimit, page)
       const queryString = genQueryString(req.query)
 
       const selectedSort = `${sort},${orderBy}`

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -10,7 +10,7 @@ const { genQueryString } = require('../lib/tools.js')
 
 function setWhere(req, where) {
   // 製作 category where
-  const categoryQuery = +req.query.category
+  let categoryQuery = +req.query.category || 0
   if (categoryQuery) { where.CategoryId = categoryQuery }
 
   // 製作 search where (商品名 or 作品名)
@@ -20,6 +20,8 @@ function setWhere(req, where) {
       name: { [Op.like]: `%${searchQuery}%` },
       '$Series.name$': { [Op.like]: `%${searchQuery}%` }
     }
+
+    categoryQuery = null  // 搜尋時，關閉分類 active 特效
   }
 
   // 製作 tag where (tagQuery 非數字者為特規)
@@ -109,15 +111,10 @@ module.exports = {
       // 製作麵包屑
       const bread = getBread(categoryQuery, req, res) || '製品一覽'
 
-      // 當為所有商品頁的 製品一覽 時為 true 
-      // search 時，取消分類 active 特效
-      let isAllProducts = categoryQuery ? false : true
-      if (req.path.includes('search')) {isAllProducts = false}
-
-      res.render('products', { 
+      res.render('products', {
         js: 'products',
         css: 'products',
-        getProducts, selectedSort, searchQuery, bread, pagesArray, queryString, categoryQuery, tagQuery, page, prev, next, isAllProducts
+        getProducts, selectedSort, searchQuery, bread, pagesArray, queryString, categoryQuery, tagQuery, page, prev, next
       })
 
     } catch (err) {

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -91,7 +91,11 @@ module.exports = {
 
       const selectedSort = `${sort},${orderBy}`
       let bread = '製品一覽'
-      if (categoryQuery) {bread = categoryQuery}
+      if (categoryQuery) { 
+        const categories = res.locals.categoryBar
+        const category = categories.find(cate => cate.id === categoryQuery)
+        bread = category.name 
+      }
       if (req.path.includes('search')) { bread ='搜尋商品'}
 
       // 當為所有商品頁的 製品一覽 時為 true 

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -18,7 +18,7 @@ module.exports = {
 
       // Category 
       const where = { status: 1 }
-      const categoryQuery = req.query.category
+      const categoryQuery = +req.query.category
       if (categoryQuery) { where.CategoryId = categoryQuery }
 
       // search 商品名 or 作品名
@@ -32,31 +32,23 @@ module.exports = {
       }
 
       // tag
-      const tagQuery = req.query.tag || '所有商品'
-      const tagId = {}
-      const tagGroup = res.locals.tagGroup
-      tagGroup.forEach(item => {
-        const key = item.name
-        const val = item.id
-        tagId[key] = val
-      })
+      let tagQuery = req.query.tag || '所有商品'
+      if (!isNaN(tagQuery)) { tagQuery = +tagQuery }
 
-      if (tagQuery) {
-        if (tagQuery == '即將截止預購') {
-          // 取得當地今日 23:99 ，再轉回時間格式
-          // 從今天往後取 7 天快截止的商品
-          const today = moment().add(7, 'days').endOf('day')
-          const todayDate = new Date(today)
+      if (tagQuery === '即將截止預購') {
+        // 取得當地今日 23:99 ，再轉回時間格式
+        // 從今天往後取 7 天快截止的商品
+        const today = moment().add(7, 'days').endOf('day')
+        const todayDate = new Date(today)
 
-          where['$tags.id$'] = 1  // 預購中
-          where.deadline = {      
-            [Op.lte]: todayDate}
+        where['$tags.id$'] = 1  // 預購中
+        where.deadline = {      
+          [Op.lte]: todayDate}
 
-        } else if (tagQuery == '所有商品') {
-          // 什麼都不加
-        } else {
-          where['$tags.id$'] = tagId[tagQuery]
-        }
+      } else if (tagQuery === '所有商品') {
+        // 什麼都不加
+      } else {
+        where['$tags.id$'] = tagQuery
       }
 
       // 設定分頁偏移

--- a/lib/product_tools.js
+++ b/lib/product_tools.js
@@ -1,0 +1,83 @@
+const Op = require('sequelize').Op
+const moment = require('moment')
+moment.locale('zh-tw')
+
+module.exports = {
+  /**
+   * 製作分頁bar，link href
+   */
+  genQueryString(query) {
+    let queryString = '?'
+    if (query.q) {
+      queryString += `q=${query.q}&`
+    }
+
+    if (query.category) {
+      queryString += `category=${query.category}&`
+    }
+
+    if (query.tag) {
+      queryString += `tag=${query.tag}&`
+    }
+
+    if (query.sort) {
+      queryString += `sort=${query.sort}&order=${query.order}&`
+    }
+
+    return queryString
+  },
+
+  setWhere(req, where) {
+    // 製作 category where
+    let categoryQuery = +req.query.category || 0
+    if (categoryQuery) { where.CategoryId = categoryQuery }
+
+    // 製作 search where (商品名 or 作品名)
+    const searchQuery = req.query.q
+    if (searchQuery) {
+      where[Op.or] = {
+        name: { [Op.like]: `%${searchQuery}%` },
+        '$Series.name$': { [Op.like]: `%${searchQuery}%` }
+      }
+
+      categoryQuery = null  // 搜尋時，關閉分類 active 特效
+    }
+
+    // 製作 tag where (tagQuery 非數字者為特規)
+    let tagQuery = req.query.tag || '所有商品'
+    const isNumber = !isNaN(tagQuery)
+    if (isNumber) {
+      tagQuery = +tagQuery
+      where['$tags.id$'] = tagQuery
+    }
+
+    if (tagQuery === '即將截止預購') {
+      // 從 Date.now 往後取 7 天快截止的商品
+      const date = moment().add(7, 'days').endOf('day')
+
+      where['$tags.id$'] = 1  // 預購中
+      where.deadline = { [Op.lte]: date }
+    }
+
+    return { categoryQuery, searchQuery, tagQuery }
+  },
+
+  getPagination(result, PAGE_LIMIT, page) {
+    const totalPages = Math.ceil(result.count / PAGE_LIMIT)
+    const pagesArray = Array.from({ length: totalPages }, (val, index) => index + 1)
+    const prev = (page === 1) ? 1 : page - 1
+    const next = (page === totalPages) ? totalPages : page + 1
+
+    return { pagesArray, prev, next }
+  },
+
+  getBread(categoryQuery, req, res) {
+    if (categoryQuery) {
+      const categories = res.locals.categoryBar
+      const category = categories.find(cate => cate.id === categoryQuery)
+      return category.name
+    }
+
+    if (req.path.includes('search')) return '搜尋商品'
+  },
+}

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -7,30 +7,6 @@ function genDataChain(data) {
 }
 
 module.exports = {
-  /**
-   * 製作分頁bar，link href
-   */
-  genQueryString(query) {
-    let queryString = '?'
-    if (query.q) {
-      queryString += `q=${query.q}&`
-    }
-    
-    if (query.category) {
-      queryString += `category=${query.category}&`
-    }
-
-    if (query.tag) {
-      queryString += `tag=${query.tag}&`
-    }
-
-    if (query.sort) {
-      queryString += `sort=${query.sort}&order=${query.order}&`
-    }
-
-    return queryString
-  },
-
   aesEncrypt(data, HashKey, HashIV) {
     const cipher = crypto.createCipheriv('aes256', HashKey, HashIV)
     const encrypted = cipher.update(genDataChain(data), 'utf8', 'hex')

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -25,7 +25,7 @@
     <div class="container">
       <ul class="nav mx-auto">
         <li class="nav-item px-3">
-          <a class="nav-link py-4 {{#if isAllProducts}}active{{/if}}" href="/products">製品一覽</a>
+          <a class="nav-link py-4 {{#ifEqual categoryQuery 0}}active{{/ifEqual}}" href="/products">製品一覽</a>
         </li>
         {{#each categoryBar}}
           <li class="nav-item px-3">

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -15,7 +15,7 @@
             </li>
             {{#each tagGroup}}
               <li class="d-inline">
-                <a class="btn btn-sm {{#ifEqual ../tagQuery this.name}}active{{/ifEqual}}" data-tag="{{this.name}}">{{this.name}}</a>
+                <a class="btn btn-sm {{#ifEqual ../tagQuery this.id}}active{{/ifEqual}}" data-tag="{{this.id}}">{{this.name}}</a>
               </li>
             {{/each}}
             <li class="d-inline">


### PR DESCRIPTION
getProducts 太大包，將其進行拆分，
並優化部分 code，減少整體行數。

效能本身沒進行優化，
只是將 code 做成 function 搬出去而已。

## 變動項
- 將 getProducts 部分 code 拆成 function，放到 `lib/product_toos.js`
- 將遠本在 `lib/tools.js` 的 genQueryString，搬移到 `lib/product_toos.js`
- pageLimit 應該是常數，於是更名為 PAGE_LIMIT
- category 與 tag，原本使用 name 來 query，現在改用 id

## 確認目標
- 前台 getProducts controller，code 長度縮減成約 1.5 個螢幕長
- 分類、搜尋、Tag、排序、分頁等功能，皆能正常工作，沒有壞掉
  - 不用太詳細的去對篩選出來的商品正不正確，因為 code 本身其實沒變動