### PR TITLE
【加入】後台商品詳細頁面更新

### DIFF
--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -40,9 +40,15 @@ module.exports = {
 
         //售價加上dot
         product.price = product.price.toLocaleString()
+
+        //校正日期格式
+        product.release = moment(product.releaseDate).format('YYYY/MM/DD')
+        product.sale = moment(product.saleDate).format('YYYY/MM/DD')
+        product.dead = moment(product.deadline).format('YYYY/MM/DD')
+
       })
 
-      console.log(products)
+      console.log(products[0])
       res.render('admin/products', { products })
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -1,5 +1,5 @@
 const db = require('../../models')
-const { Product, Category, Series, Image, Tag, TagItem } = db
+const { Product, Category, Series, Image, Tag, TagItem, Gift } = db
 const moment = require('moment')
 
 const imgur = require('imgur')
@@ -13,7 +13,7 @@ module.exports = {
     try {
       const products = await Product.findAll({
         order: [['id', 'DESC']],
-        include: [Category, Series, Image, 'tags']
+        include: [Category, Series, Image, Gift,'tags']
       })
 
       //判斷日期用
@@ -41,6 +41,8 @@ module.exports = {
         //售價加上dot
         product.price = product.price.toLocaleString()
       })
+
+      console.log(products)
       res.render('admin/products', { products })
     } catch (err) {
       console.error(err)

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -124,6 +124,17 @@
                       <p>廠商： {{this.maker}}</p>
                       <p>版權： {{this.copyright}}</p>
                       <p>規格： {{this.spec}}</p>
+                      <p>
+                        <span>特典：
+                          {{#if this.Gifts}}
+                            {{#each this.Gifts}}
+                              {{this.name}}
+                            {{/each}}
+                          {{else}}
+                            無
+                          {{/if}}
+                        </span>
+                      </p>
                     </div>
                     <div class="col-6 ">
                       <p>分類： {{this.Category.name}}</p>
@@ -135,17 +146,7 @@
                         {{/each}}
                       </p>
                       
-                      <p>
-                        <span>特典：
-                          {{#if this.Gifts}}
-                           {{#each this.Gifts}}
-                            {{this.name}}
-                           {{/each}}
-                          {{else}}
-                            無
-                          {{/if}}
-                        </span>
-                      </p>
+
                       <p>公開日期： {{this.release}}</p>
                       <p>發售日期： {{this.sale}}</p>
                       <p>預購截止日期： {{this.dead}}</p>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -145,11 +145,9 @@
                           <span>#{{this.name}}</span>
                         {{/each}}
                       </p>
-                      
-
                       <p>公開日期： {{this.release}}</p>
-                      <p>發售日期： {{this.sale}}</p>
                       <p>預購截止： {{this.dead}}</p>
+                      <p>發售日期： {{this.sale}}</p>
                     </div>
                   </div>
                   <hr>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -146,7 +146,9 @@
                           {{/if}}
                         </span>
                       </p>
-                      
+                      <p>公開日期： {{this.release}}</p>
+                      <p>發售日期： {{this.sale}}</p>
+                      <p>預購截止日期： {{this.dead}}</p>
                     </div>
                   </div>
                   <hr>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -134,6 +134,19 @@
                           <span>#{{this.name}}</span>
                         {{/each}}
                       </p>
+                      
+                      <p>
+                        <span>特典：
+                          {{#if this.Gifts}}
+                           {{#each this.Gifts}}
+                            {{this.name}}
+                           {{/each}}
+                          {{else}}
+                            無
+                          {{/if}}
+                        </span>
+                      </p>
+                      
                     </div>
                   </div>
                   <hr>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -149,7 +149,7 @@
 
                       <p>公開日期： {{this.release}}</p>
                       <p>發售日期： {{this.sale}}</p>
-                      <p>預購截止日期： {{this.dead}}</p>
+                      <p>預購截止： {{this.dead}}</p>
                     </div>
                   </div>
                   <hr>


### PR DESCRIPTION

<img width="1263" alt="螢幕快照 2020-01-18 下午4 37 02" src="https://user-images.githubusercontent.com/49901777/72661086-3833df00-3a11-11ea-80ed-dd32035e7063.png">


## PR內容
- 商品詳細頁面加入特典資訊
   - 有特典會顯示特典名稱
   - 若無特典會顯示`無`
- 商品詳細頁面加入相關日期資訊
   - 公開日期
   - 預購截止日期 (顯示為預購截止統一四個字)
   - 發售日期