### PR TITLE
【修改】Tag，前台商品顯示邏輯

### DIFF
--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -18,6 +18,7 @@ module.exports = {
 
       // 製作 db where 物件
       const where = { status: 1 }
+      const now = new Date()
       const { categoryQuery, searchQuery, tagQuery } = setWhere(req, where)
 
       // db Query
@@ -43,7 +44,8 @@ module.exports = {
       getProducts.forEach(product => {
         product.mainImg = product.Images.find(img => img.isMain).url
         product.priceFormat = product.price.toLocaleString()
-        product.isOnSale = moment().isAfter(product.saleDate)
+        product.isOnSale = moment(now).isAfter(product.saleDate)
+        product.isPreOrder = moment(now).isBefore(product.deadline)
         product.isGift = product.Gifts.length > 0 ? true : false
         product.hasInv = (product.inventory !== 0)
       })
@@ -84,13 +86,14 @@ module.exports = {
       if (!product) return res.redirect('/products')
 
       // 頁面所需 data
+      const now = new Date()
       product.priceFormat = product.price.toLocaleString()
       product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
       product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')
       product.deadlineFormat = moment(product.deadline).format('YYYY年MM月DD日(dd)')
       product.hasGift = (product.Gifts.length !== 0) ? true : false
-      product.isOnSale = moment().isAfter(product.saleDate)
-      product.isPreOrder = moment().isBefore(product.deadline)
+      product.isOnSale = moment(now).isAfter(product.saleDate)
+      product.isPreOrder = moment(now).isBefore(product.deadline)
       product.hasInv = (product.inventory !== 0)
       product.category = product.Category.name
 

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -1,6 +1,7 @@
 const db = require('../models')
 const { Product, Image, Gift } = db
 
+const Op = require('sequelize').Op
 const moment = require('moment')
 moment.locale('zh-tw')
 
@@ -17,10 +18,12 @@ module.exports = {
       const selectedSort = `${sort},${orderBy}`
 
       // 製作 db where 物件
-      const where = { status: 1 }
       const now = new Date()
+      const where = { status: 1,
+        [Op.or]: { deadline: { [Op.gte]: now }, saleDate: { [Op.lte]: now } }
+      }
       const { categoryQuery, searchQuery, tagQuery } = setWhere(req, where)
-
+      console.log(where)
       // db Query
       const result = await Product.findAndCountAll({
         include: [

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -23,7 +23,7 @@ module.exports = {
         [Op.or]: { deadline: { [Op.gte]: now }, saleDate: { [Op.lte]: now } }
       }
       const { categoryQuery, searchQuery, tagQuery } = setWhere(req, where)
-      console.log(where)
+
       // db Query
       const result = await Product.findAndCountAll({
         include: [

--- a/lib/product_tools.js
+++ b/lib/product_tools.js
@@ -53,10 +53,10 @@ module.exports = {
 
     if (tagQuery === '即將截止預約') {
       // 從 Date.now 往後取 7 天快截止的商品
-      const date = moment().add(7, 'days').endOf('day')
+      const now = new Date()
+      const end = moment().add(7, 'days').endOf('day')
 
-      where['$tags.name$'] = '預約中'  // 預約中
-      where.deadline = { [Op.lte]: date }
+      where.deadline = { [Op.between]: [now, end] }
     }
 
     return { categoryQuery, searchQuery, tagQuery }

--- a/views/product.hbs
+++ b/views/product.hbs
@@ -59,12 +59,14 @@
           <div class="mb-0 text-center">
             {{#if product.isOnSale}}
               {{#if product.hasInv}}
-                <p class="mb-2 status-text">發售中</p>
+                <span class="mb-2 status-text">發售中</span>
               {{else}}
-                <p class="mb-2 status-sold-out">已售完</p>
+                <span class="mb-2 status-sold-out">已售完</span>
               {{/if}}
+            {{else if product.isPreOrder}}
+              <span class="mb-2 status-text">預約中</span>
             {{else}}
-              <p class="mb-2 status-text">預約中</p>
+              <span class="mb-2 status-sold-out">預約已截止</span>
             {{/if}}
             <hr class="my-2">
             <div class="d-flex px-3 mb-2 justify-content-between align-items-center">
@@ -161,8 +163,10 @@
               {{else}}
                 <span class="status-sold-out">已售完</span>
               {{/if}}
-            {{else}}
+            {{else if product.isPreOrder}}
               <span class="status-text">預約中</span>
+            {{else}}
+              <span class="status-sold-out">預約已截止</span>
             {{/if}}
           </div>
         </div>

--- a/views/products.hbs
+++ b/views/products.hbs
@@ -51,14 +51,16 @@
                   <div class="card-img-top card-bg mb-3">
                     <img src="{{this.mainImg}}" class="w-100">
                   </div>
-                  {{#if hasInv}}
-                    {{#if isOnSale}}
+                  {{#if isOnSale}}
+                    {{#if hasInv}}
                       <span class="tag tag-preorder">發售中</span>
                     {{else}}
-                      <span class="tag tag-preorder">預約中</span>
+                      <span class="tag tag-sold-out">已售完</span>
                     {{/if}}
+                  {{else if isPreOrder}}
+                    <span class="tag tag-preorder">預約中</span>
                   {{else}}
-                    <span class="tag tag-sold-out">已售完</span>
+                    <span class="tag tag-sold-out">預約已截止</span>
                   {{/if}}
                   {{#if isGift}}
                     <span class="tag tag-gift">特典</span>


### PR DESCRIPTION
重建前台商品，顯示邏輯。
現在前台不會顯示 deadline ~ saleDate 之間，處於「等待發售」的商品。

為了確認方便，前台加入了提示機制，commit 為：
 [加入] 前台商品能顯示「預約截止」提示

請先 checkout 到該 commit，依照我們目前的 seeder 資料，
應該有些商品已過了 deadline，但 tag 仍為「預購中」，
該類商品應該會出現下圖的情況：
<img src="https://i.gyazo.com/92c7e478a15753539fe8aeb6b9c12389.png" width="400">

## 確認目標
先將 commit 切回最新
- 製品一覽，點選 Tag「預購中」，應不會出現「預約已截止」商品
- 製品一覽，點選 Tag 「即將截止預約」 ，應不會出現「預約已截止」商品
  - 即將截止預約，篩選邏輯改由純靠 deadline 判斷，而不判斷「預約中」 Tag
  - 將其中一件商品的預約中 tag 拔掉，應該仍然可以被篩選出來
  - 可輸入下方 MySQL 雙重比對，出現的商品應該大致相同 (time計算問題，會有一兩件誤差)
```
SELECT products.id, products.deadline, products.sale_date, tags.name FROM products
LEFT JOIN tag_items AS items ON products.id = items.product_id
LEFT JOIN tags ON items.tag_id = tags.id
WHERE deadline between NOW() AND NOW() + interval 7 day;
```