### PR TITLE
【debug】修復 heroku 時區問題

### DIFF
--- a/controllers/admin/paymentCtrller.js
+++ b/controllers/admin/paymentCtrller.js
@@ -24,7 +24,7 @@ module.exports = {
       // SN、時間格式
       payments.forEach(payment => {
         payment.SN = ("000000000" + inputSn).slice(-10)
-        payment.payDate = moment(payment.payTime).format('YYYY/MM/DD HH:mm')
+        payment.payDate = moment(payment.payTime).tz('Asia/Taipei').format('YYYY/MM/DD HH:mm')
       });
 
       res.render('admin/payments', { payments, showSn })

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -42,9 +42,9 @@ module.exports = {
         product.price = product.price.toLocaleString()
 
         //校正日期格式
-        product.release = moment(product.releaseDate).format('YYYY/MM/DD')
-        product.sale = moment(product.saleDate).format('YYYY/MM/DD')
-        product.dead = moment(product.deadline).format('YYYY/MM/DD')
+        product.release = moment(product.releaseDate).tz('Asia/Taipei').format('YYYY/MM/DD')
+        product.sale = moment(product.saleDate).tz('Asia/Taipei').format('YYYY/MM/DD')
+        product.dead = moment(product.deadline).tz('Asia/Taipei').format('YYYY/MM/DD')
 
       })
 

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -378,7 +378,6 @@ module.exports = {
 
       // 解密、整理資料
       const tradeInfo = JSON.parse(aesDecrypt(req.body.TradeInfo, HashKey, HashIV))
-      console.log(tradeInfo)
 
       // 防止不同用戶 "同時" 進行支付，此時不對資料庫操作
       if (tradeInfo.Message === '已存在相同的商店訂單編號') return res.redirect('/orders')

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -385,7 +385,7 @@ module.exports = {
 
       const orderNo = tradeInfo.Result.MerchantOrderNo
       let payTime = tradeInfo.Result.PayTime
-      payTime = payTime.slice(0, 10) + 'T' + payTime.slice(10)
+      payTime = payTime.slice(0, 10) + 'T' + payTime.slice(10) + '+08:00'
 
       // 更新資料庫
       const order = await Order.findOne({ where: { orderNo } })

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -326,10 +326,11 @@ module.exports = {
 
       // 取出、整理購物 data
       const data = req.flash('passData')[0]
-      const orderDate = moment(data.createdAt).format('YYYY/MM/DD HH:mm')
+      const twDate = moment(data.createdAt).tz('Asia/Taipei')
+      const orderDate = twDate.format('YYYY/MM/DD HH:mm')
 
       // 付款期限三天 (臨時)
-      const paymentTerms = moment(data.createdAt).add(3, 'days').format('YYYY/MM/DD')
+      const paymentTerms = twDate.add(3, 'days').format('YYYY/MM/DD')
 
       res.render('success', { css: 'success', data, orderDate, paymentTerms })
 

--- a/controllers/prodCtrller.js
+++ b/controllers/prodCtrller.js
@@ -105,9 +105,9 @@ module.exports = {
 
       // 頁面所需 data
       product.priceFormat = product.price.toLocaleString()
-      product.saleDateFormat = moment(product.saleDate).format('YYYY年MM月')
-      product.releaseDateFormat = moment(product.releaseDate).format('YYYY年MM月DD日(dd)')
-      product.deadlineFormat = moment(product.deadline).format('YYYY年MM月DD日(dd)')
+      product.saleDateFormat = moment(product.saleDate).tz('Asia/Taipei').format('YYYY年MM月')
+      product.releaseDateFormat = moment(product.releaseDate).tz('Asia/Taipei').format('YYYY年MM月DD日(dd)')
+      product.deadlineFormat = moment(product.deadline).tz('Asia/Taipei').format('YYYY年MM月DD日(dd)')
       product.hasGift = (product.Gifts.length !== 0) ? true : false
       product.isOnSale = moment(now).isAfter(product.saleDate)
       product.isPreOrder = moment(now).isBefore(product.deadline)


### PR DESCRIPTION
使用 `moment-timezone`，將後端有使用 `moment().format()` 整理時間的部分，
皆指定為台北時區 `moment().tz('Asia/Taipei').format()`。

修復藍新金流，payTime 誤存成國際標準時間的錯誤。

移除了串金流頁，測試確認用的 console.log。

## 確認目標
先將自己的電腦時區，改成 +00:00 國際標準時間。
- 訂單成功頁，顯示的訂單成立時間，應為台北時間。
- 串金流付款後，資料庫紀錄的 pay_time，應為台北時間，而不會多 8 小時。
- 後台該筆 payment 顯示的付款時間，應為台北時間。