### PR TITLE
【修改】後台商品頁面改為後端分頁

### DIFF
--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -7,7 +7,7 @@ const IMGUR_CLIENT_ID = process.env.IMGUR_CLIENT_ID
 imgur.setClientId(IMGUR_CLIENT_ID)
 
 const {checkProduct} = require('../../lib/checker.js')
-const PAGE_LIMIT = 10
+const PAGE_LIMIT = 20
 const { genQueryString, setWhere, getPagination} = require('../../lib/product_tools.js')
 
 module.exports = {

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -48,7 +48,7 @@ module.exports = {
 
       })
 
-      res.render('admin/products', { products })
+      res.render('admin/products', { products , css:'products'})
 
     } catch (err) {
       console.error(err)

--- a/controllers/admin/prodCtrller.js
+++ b/controllers/admin/prodCtrller.js
@@ -13,9 +13,16 @@ const { genQueryString, setWhere, getPagination} = require('../../lib/product_to
 module.exports = {
   getProducts: async (req, res) => {
     try {
+
+      // 製作 db where 物件
+      const now = new Date()
+      const where = { }
+      const { searchQuery } = setWhere(req, where)
+
       const result = await Product.findAndCountAll({
         order: [['id', 'DESC']],
-        include: [Category, Series, Image, Gift,'tags']
+        include: [Category, Series, Image, Gift,'tags'],
+        where
       })
 
 
@@ -67,7 +74,12 @@ module.exports = {
 
       res.render('admin/products', { 
         getProducts,
-        pagesArray, page, prev, next, queryString,
+        pagesArray, 
+        page, 
+        prev, 
+        next, 
+        queryString, 
+        searchQuery,
         css:'products'})
 
     } catch (err) {

--- a/public/css/admin/products.css
+++ b/public/css/admin/products.css
@@ -1,0 +1,7 @@
+.table td {
+    vertical-align: middle;
+}
+
+.product-name {
+    width: 150px;
+}

--- a/routes/admin/products.js
+++ b/routes/admin/products.js
@@ -9,6 +9,7 @@ const upload = multer({ dest: 'temp/' })
 
 router.get('/', prodCtrller.getProducts)
 router.get('/new', prodCtrller.getAddPage)
+router.get('/search', prodCtrller.getProducts)
 router.get('/:id/edit', prodCtrller.getEditPage)
 router.get('/:id/preview', frontProdCtrller.getProduct)
 

--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -7,7 +7,7 @@
         </div>
         <form class="form-inline d-flex justify-content-end" action="/admin/categories" method="POST">
           <div class="form-group mx-sm-3 mb-2 mt-1">
-            <input type="text" class="form-control" name="name" placeholder="輸入新分類..." required>
+            <input type="text" class="form-control input-center" name="name" placeholder="輸入新分類..." required>
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1">新增分類</button>
         </form>
@@ -75,7 +75,7 @@
                     <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
                       <form class="" action="/admin/categories/{{this.id}}?_method=PUT" method="POST" id="edit_{{this.id}}">
                         <div class="form-group mx-sm-3 mb-2 mt-1">
-                          <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..."
+                          <input type="text" class="form-control input-center" name="name" placeholder="輸入分類名稱..."
                             value="{{this.name}}" required>
                         </div>
                       </form>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -1,5 +1,5 @@
 <main class="container">
-  <div class="card-body pt-4">
+  <div class="card-body pt-4 pb-0">
     <form action="products/search" method="GET" class="mb-3 col-2 float-right pr-0">
       <div class="input-group">
         <input type="text" name="q" class="form-control" placeholder="search" value="{{searchQuery}}">
@@ -58,16 +58,16 @@
                 </form>
               {{/if}}
             </td>
-            <td class="text-center">
-              <button type="button" class="btn font-weight-normal">
+            <td class="text-center px-1">
+              <button type="button" class="btn btn-outline-dark font-weight-normal mr-1">
                 <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark "><i
                     class="fas fa-edit" title="編輯此商品"></i></a>
               </button>
               <!-- Detail Button trigger modal -->
-              <button type="button" class="btn font-weight-normal" data-toggle="modal"
+              <button type="button" class="btn btn-outline-dark font-weight-normal mr-1" data-toggle="modal"
                 data-target=".detailModal{{this.id}}"><i class="fas fa-search-plus" title="商品詳情"></i></button>
               <!-- Delete Button trigger modal -->
-              <button type="button" class="btn font-weight-normal" data-toggle="modal" data-target="#delete_{{this.id}}"
+              <button type="button" class="btn btn-outline-danger font-weight-normal mr-1" data-toggle="modal" data-target="#delete_{{this.id}}"
                 title="刪除此商品">
                 <i class="far fa-trash-alt" aria-hidden="true"></i>
               </button>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -1,6 +1,6 @@
 <main class="container">
   <div class="card-body pt-4">
-    <table data-toggle="table" data-search="true" data-show-columns="true" data-pagination="true" id="table">
+    <table class="table table-hover" id="table">
       <thead>
         <tr>
           <th data-valign="middle" class="text-center" data-sortable="true">#</th>
@@ -18,24 +18,24 @@
       <tbody>
         {{#each products}}
           <tr>
-            <td>{{this.id}}</td>
-            <td>
+            <td class="text-center">{{this.id}}</td>
+            <td class="text-center">
               <a href="/admin/products/{{this.id}}/preview" target="_blank" class="text-decoration-none text-dark d-block">
                 <img src="{{this.mainImg}}" title="{{this.name}}" class="rounded mx-auto d-block" alt="productImage"
                   style="height:50px">
               </a>
             </td>
-            <td>
+            <td class="text-center product-name">
               <a href="/admin/products/{{this.id}}/preview" target="_blank" class="text-decoration-none text-dark d-block">
                 {{this.name}}
               </a>
             </td>
-            <td>{{this.price}}</td>
-            <td>{{this.inventory}}</td>
-            <td>{{this.Category.name}}</td>
-            <td>{{this.Series.name}}</td>
-            <td>{{this.saleStatus}}</td>
-            <td>
+            <td class="text-center">{{this.price}}</td>
+            <td class="text-center">{{this.inventory}}</td>
+            <td class="text-center">{{this.Category.name}}</td>
+            <td class="text-center">{{this.Series.name}}</td>
+            <td class="text-center">{{this.saleStatus}}</td>
+            <td class="text-center">
               {{#if this.status}}
                 <p hidden>1</p>
                 {{!-- 排序用 --}}
@@ -53,7 +53,7 @@
                 </form>
               {{/if}}
             </td>
-            <td>
+            <td class="text-center">
               <button type="button" class="btn font-weight-normal">
                 <a href="/admin/products/{{this.id}}/edit" class="text-decoration-none text-dark "><i
                     class="fas fa-edit" title="編輯此商品"></i></a>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -1,6 +1,6 @@
 <main class="container">
   <div class="card-body pt-4 pb-0">
-    <form action="products/search" method="GET" class="mb-3 col-2 float-right pr-0">
+    <form action="/admin/products/search" method="GET" class="mb-3 col-2 float-right pr-0">
       <div class="input-group">
         <input type="text" name="q" class="form-control" placeholder="search" value="{{searchQuery}}">
       </div>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -16,7 +16,7 @@
         </tr>
       </thead>
       <tbody>
-        {{#each products}}
+        {{#each getProducts}}
           <tr>
             <td class="text-center">{{this.id}}</td>
             <td class="text-center">
@@ -179,5 +179,9 @@
         {{/each}}
       </tbody>
     </table>
+  </div>
+  {{!-- 分頁 --}}
+  <div class="float-right pr-4">
+    {{>pagination}}
   </div>
 </main>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -1,5 +1,10 @@
 <main class="container">
   <div class="card-body pt-4">
+    <form action="products/search" method="GET" class="mb-3 col-2 float-right pr-0">
+      <div class="input-group">
+        <input type="text" name="q" class="form-control" placeholder="search" value="{{searchQuery}}">
+      </div>
+    </form>
     <table class="table table-hover" id="table">
       <thead>
         <tr>

--- a/views/admin/series.hbs
+++ b/views/admin/series.hbs
@@ -7,7 +7,7 @@
         </div>
         <form class="form-inline d-flex justify-content-end" action="/admin/series" method="POST">
           <div class="form-group mx-sm-3 mb-2 mt-1">
-            <input type="text" class="form-control" name="name" placeholder="輸入新作品別..." required>
+            <input type="text" class="form-control input-center" name="name" placeholder="輸入新作品別..." required>
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1">新增作品別</button>
         </form>
@@ -77,7 +77,7 @@
                       <form class="" action="/admin/series/{{this.id}}?_method=PUT" method="POST"
                         id="edit_{{this.id}}">
                         <div class="form-group mx-sm-3 mb-2 mt-1">
-                          <input type="text" class="form-control" name="name" placeholder="輸入作品別名稱..."
+                          <input type="text" class="form-control input-center" name="name" placeholder="輸入作品別名稱..."
                             value="{{this.name}}" required>
                         </div>
                       </form>


### PR DESCRIPTION
<img width="1440" alt="螢幕快照 2020-01-31 下午2 15 17" src="https://user-images.githubusercontent.com/49901777/73517009-361c4800-4435-11ea-9f75-71af7a0de008.png">

## PR內容
- 後台商品分頁改為後端分頁
  - 優化按鈕外觀與其他頁一致
  - 保有搜尋功能
- 順手修復作品與分類頁input未置中情形

## 手動確認
- 登入後台，改為後端分頁後加快載入速度
- 分頁可以正常運作
- 搜尋欄可以關鍵字搜尋商品名稱
- 搜尋關鍵字會留存於input中

## 其他
 - 排序功能未實作，先確認是否要改為後端分頁