### PR TITLE
【優化】後台調整

### DIFF
--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -7,7 +7,7 @@
         </div>
         <form class="form-inline d-flex justify-content-end" action="/admin/categories" method="POST">
           <div class="form-group mx-sm-3 mb-2 mt-1">
-            <input type="text" class="form-control" name="name" placeholder="輸入新分類..." required>
+            <input type="text" class="form-control input-center" name="name" placeholder="輸入新分類..." required>
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1">新增分類</button>
         </form>
@@ -75,7 +75,7 @@
                     <div class="collapse" id="collapse_{{this.id}}" data-parent="#accordionEdit">
                       <form class="" action="/admin/categories/{{this.id}}?_method=PUT" method="POST" id="edit_{{this.id}}">
                         <div class="form-group mx-sm-3 mb-2 mt-1">
-                          <input type="text" class="form-control" name="name" placeholder="輸入分類名稱..."
+                          <input type="text" class="form-control input-center" name="name" placeholder="輸入分類名稱..."
                             value="{{this.name}}" required>
                         </div>
                       </form>

--- a/views/admin/series.hbs
+++ b/views/admin/series.hbs
@@ -7,7 +7,7 @@
         </div>
         <form class="form-inline d-flex justify-content-end" action="/admin/series" method="POST">
           <div class="form-group mx-sm-3 mb-2 mt-1">
-            <input type="text" class="form-control" name="name" placeholder="輸入新作品別..." required>
+            <input type="text" class="form-control input-center" name="name" placeholder="輸入新作品別..." required>
           </div>
           <button type="submit" class="btn btn-primary mb-2 mt-1">新增作品別</button>
         </form>
@@ -77,7 +77,7 @@
                       <form class="" action="/admin/series/{{this.id}}?_method=PUT" method="POST"
                         id="edit_{{this.id}}">
                         <div class="form-group mx-sm-3 mb-2 mt-1">
-                          <input type="text" class="form-control" name="name" placeholder="輸入作品別名稱..."
+                          <input type="text" class="form-control input-center" name="name" placeholder="輸入作品別名稱..."
                             value="{{this.name}}" required>
                         </div>
                       </form>

--- a/views/layouts/admin.hbs
+++ b/views/layouts/admin.hbs
@@ -34,10 +34,7 @@
           <a class="nav-link {{#ifEqual path '/products'}}active{{/ifEqual}}" href="/admin/products">商品</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {{#ifEqual path '/orders'}}active{{/ifEqual}}" href="/admin/orders?mode=uncancel">訂單</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link {{#ifEqual path '/users'}}active{{/ifEqual}}" href="/admin/users">會員</a>
+          <a class="nav-link {{#ifEqual path '/gifts'}}active{{/ifEqual}}" href="/admin/gifts">特典</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {{#ifEqual path '/categories'}}active{{/ifEqual}}" href="/admin/categories">分類</a>
@@ -49,10 +46,13 @@
           <a class="nav-link {{#ifEqual path '/series'}}active{{/ifEqual}}" href="/admin/series">作品別</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {{#ifEqual path '/payments'}}active{{/ifEqual}}" href="/admin/payments">交易紀錄</a>
+          <a class="nav-link {{#ifEqual path '/users'}}active{{/ifEqual}}" href="/admin/users">會員</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {{#ifEqual path '/gifts'}}active{{/ifEqual}}" href="/admin/gifts">特典</a>
+          <a class="nav-link {{#ifEqual path '/orders'}}active{{/ifEqual}}" href="/admin/orders?mode=uncancel">訂單</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {{#ifEqual path '/payments'}}active{{/ifEqual}}" href="/admin/payments">交易紀錄</a>
         </li>
         <br>
       </ul>


### PR DESCRIPTION
## PR內容
- 修復作品與分類兩個頁面，input尚未置中的問題
- 調整後台navbar的順序，改為與商品相關放至前面，交易相關改為後面

<img width="1440" alt="螢幕快照 2020-02-01 下午2 43 30" src="https://user-images.githubusercontent.com/49901777/73588208-3f72e680-4501-11ea-877b-b4a4d0dc4277.png">

## 手動測試
- 登入後台，navbar的排序是否有修改
- 作品頁面，新增與編輯的input是否已置中
- 分類頁面，新增與編輯的input是否已置中