### PR TITLE
【fix】修復後台商品預覽，分類bar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# session config
+SESSION_NAME=name
+SESSION_KEY=secret
+
 # DB config
 MYSQL_USER=user_name
 MYSQL_KEY=password
@@ -6,11 +10,11 @@ MYSQL_DATABASE_TEST=db_test_name
 MYSQL_HOST=host_IP
 
 # Imgur API
-IMGUR_CLIENT_ID=
+IMGUR_CLIENT_ID=id
 
 # Gmail config
-GMAIL_USER=
-GMAIL_KEY=
+GMAIL_USER=email
+GMAIL_KEY=password
 
 # newebpay API
 HOST_URL=from_ngrok

--- a/app.js
+++ b/app.js
@@ -25,8 +25,8 @@ app.use('/favicon.ico', express.static('public/favicon.ico'))
 app.use(flash())
 
 app.use(session({
-  secret: 'LastWendyTomatoBurger',
-  name: 'greatSmile',
+  secret: process.env.SESSION_KEY,
+  name: process.env.SESSION_NAME,
   cookie: { maxAge: 1000*60*10 },
   resave: false,
   saveUninitialized: false

--- a/controllers/cartCtrller.js
+++ b/controllers/cartCtrller.js
@@ -1,7 +1,6 @@
 const db = require('../models')
-const { Product, Cart, CartItem} = db
+const { Product, Cart, CartItem } = db
 
-const Op = require('sequelize').Op
 const moment = require('moment')
 moment.locale('zh-tw')
 

--- a/routes/admin/products.js
+++ b/routes/admin/products.js
@@ -1,6 +1,7 @@
 const router = require('express').Router()
 const prodCtrller = require('../../controllers/admin/prodCtrller.js')
 const frontProdCtrller = require('../../controllers/prodCtrller.js')
+const { getCategoryBar } = require('../../middleware/category.js')
 
 const multer = require('multer')
 const upload = multer({ dest: 'temp/' })
@@ -10,7 +11,7 @@ const upload = multer({ dest: 'temp/' })
 router.get('/', prodCtrller.getProducts)
 router.get('/new', prodCtrller.getAddPage)
 router.get('/:id/edit', prodCtrller.getEditPage)
-router.get('/:id/preview', frontProdCtrller.getProduct)
+router.get('/:id/preview', getCategoryBar, frontProdCtrller.getProduct)
 
 router.post('/', upload.array('image', 10), prodCtrller.postNewProduct)
 router.post('/:id/display', prodCtrller.postDisplay)


### PR DESCRIPTION
- 修復後台商品 preview 頁，分類bar消失的問題
- 更改 session 設定方式 (dotenv)

session 設定改設在環境變數，並更動了密碼。
已將新密碼放在看板 sprint 1 資料存放區。

## 確認目標
- 現在後台商品 preview 應能正常顯示分類bar
- 添加 session 設定進 .env 後，能正常登入、操作購物車
  - `.env.example` 有新增 session 設定範例