### PR TITLE
【重構】postOrder 改用 transaction 機制

### DIFF
--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -1,5 +1,5 @@
 const db = require('../models')
-const { Cart, CartItem, Order, OrderItem, Delivery, Payment, Product } = db
+const { Cart, CartItem, Order, Delivery, Payment } = db
 
 const moment = require('moment')
 moment.locale('zh-tw')

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -249,7 +249,7 @@ module.exports = {
       if (order instanceof Error) { throw order }
 
       // send Email
-      const mail = getMailObj(data, req.user, order, sn)
+      const mail = getMailObj(data, req.user, order, order.sn)
       transporter.sendMail(mail, (err, info) => {
         if (err) return console.error(err)
         console.log(`Email sent: ${info.response}`)
@@ -257,7 +257,7 @@ module.exports = {
       
       // 傳遞資料給 success 頁
       passData.id = order.id
-      passData.sn = sn
+      passData.sn = order.sn
       passData.createdAt = order.createdAt
       req.flash('passData', passData)
       req.flash('isCreated', true)

--- a/controllers/orderCtrller.js
+++ b/controllers/orderCtrller.js
@@ -217,17 +217,12 @@ module.exports = {
 
   async postOrder(req, res) {
     try {
-      // 確認攜帶 passData
       const passData = req.flash('passData')[0]
-      if (!passData) {
-        req.flash('error', '錯誤訪問')
-        return res.redirect('/cart')
-      }
-
-      // 確認已通過各表單 passedSteps
       const passedSteps = req.flash('passedSteps')
+
+      // 確認是否為正當進入
       const isPassed = [0, 1, 2, 3].every(step => passedSteps.includes(step))
-      if (!isPassed) {
+      if (!passData || !isPassed) {
         req.flash('error', '錯誤訪問')
         return res.redirect('/cart')
       }

--- a/lib/order_helper.js
+++ b/lib/order_helper.js
@@ -1,30 +1,41 @@
 const db = require('../models')
-const { sequelize } = db
+const Op = db.Sequelize.Op
+const { sequelize, Product, Order, OrderItem, CartItem } = db
 
 module.exports = {
-  checkInv(products, cartProds) {
-    // 檢索無庫存商品
-    const noInvProds = []
-    for (const prod of products) {
-      const cartProd = cartProds.find(item => item.id === prod.id)
-      const inventory = (prod.inventory - cartProd.CartItem.quantity)
-      if (inventory < 0) { noInvProds.push({ name: prod.name, qty: prod.inventory }) }
-    }
+  async checkInv(data) {
+    try {
+      // Query Product
+      const cartProds = data.cart.products
+      const queryArray = cartProds.map(prod => ({ id: prod.id }))
+      const products = await Product.findAll({ where: { [Op.or]: queryArray } })
 
-    if (noInvProds.length) {
-      let msg = ''
-      for (const prod of noInvProds) {
-        msg += `${prod.name}，庫存剩餘 ${prod.qty} 件，已超出您選購的數量\n`
+      // 檢索無庫存商品
+      const noInvProds = []
+      for (const prod of products) {
+        const cartProd = cartProds.find(item => item.id === prod.id)
+        const inventory = (prod.inventory - cartProd.CartItem.quantity)
+        if (inventory < 0) { noInvProds.push({ name: prod.name, qty: prod.inventory }) }
       }
-      return msg
+
+      if (noInvProds.length) {
+        let msg = ''
+        for (const prod of noInvProds) {
+          msg += `${prod.name}，庫存剩餘 ${prod.qty} 件，已超出您選購的數量\n`
+        }
+        return msg
+      }
+
+    } catch (err) { 
+      return err.toString()
     }
   },
 
-  async txnOrder() {
+  async txnOrder(userId, data) {
     try {
-      await sequelize.transaction(async t => {
+      const order = await sequelize.transaction(async t => {
         // 扣除商品庫存
-        for (const prod of cartProds) {
+        for (const prod of data.cart.products) {
           await Product.decrement(
             { inventory: prod.CartItem.quantity },
             { where: { id: prod.id }, transaction: t },
@@ -34,7 +45,7 @@ module.exports = {
         // Create Order
         const order = await Order.create({
           ...data,
-          UserId: req.user.id,
+          UserId: userId,
           payStatus: false,
           shipStatus: false
         })
@@ -53,8 +64,15 @@ module.exports = {
             product_id: prod.id
           })
         }
+
+        // 清除購物車 items
+        await CartItem.destroy({ where: { CartId: cart.id } })
+
+        return order
       })
 
-    } catch (error) { return error }
+      return order
+
+    } catch (err) { return err }
   }
 }

--- a/lib/order_helper.js
+++ b/lib/order_helper.js
@@ -1,0 +1,60 @@
+const db = require('../models')
+const { sequelize } = db
+
+module.exports = {
+  checkInv(products, cartProds) {
+    // 檢索無庫存商品
+    const noInvProds = []
+    for (const prod of products) {
+      const cartProd = cartProds.find(item => item.id === prod.id)
+      const inventory = (prod.inventory - cartProd.CartItem.quantity)
+      if (inventory < 0) { noInvProds.push({ name: prod.name, qty: prod.inventory }) }
+    }
+
+    if (noInvProds.length) {
+      let msg = ''
+      for (const prod of noInvProds) {
+        msg += `${prod.name}，庫存剩餘 ${prod.qty} 件，已超出您選購的數量\n`
+      }
+      return msg
+    }
+  },
+
+  async txnOrder() {
+    try {
+      await sequelize.transaction(async t => {
+        // 扣除商品庫存
+        for (const prod of cartProds) {
+          await Product.decrement(
+            { inventory: prod.CartItem.quantity },
+            { where: { id: prod.id }, transaction: t },
+          )
+        }
+
+        // Create Order
+        const order = await Order.create({
+          ...data,
+          UserId: req.user.id,
+          payStatus: false,
+          shipStatus: false
+        })
+
+        // 加入單號 SN
+        const sn = ("000000000" + order.id).slice(-10)
+        await order.update({ sn })
+
+        // Create OrderItem
+        const cart = data.cart
+        for (const prod of cart.products) {
+          await OrderItem.create({
+            price: prod.price,
+            quantity: prod.quantity,
+            OrderId: order.id,
+            product_id: prod.id
+          })
+        }
+      })
+
+    } catch (error) { return error }
+  }
+}

--- a/lib/order_helper.js
+++ b/lib/order_helper.js
@@ -26,9 +26,7 @@ module.exports = {
         return msg
       }
 
-    } catch (err) { 
-      return err.toString()
-    }
+    } catch (err) { return err.toString() }
   },
 
   async txnOrder(userId, data) {

--- a/lib/order_helper.js
+++ b/lib/order_helper.js
@@ -48,11 +48,11 @@ module.exports = {
           UserId: userId,
           payStatus: false,
           shipStatus: false
-        })
+        }, { transaction: t })
 
         // 加入單號 SN
         order.sn = ("000000000" + order.id).slice(-10)
-        await order.save()
+        await order.save({ transaction: t })
 
         // Create OrderItem
         const cart = data.cart
@@ -62,11 +62,11 @@ module.exports = {
             quantity: prod.quantity,
             OrderId: order.id,
             product_id: prod.id
-          })
+          }, { transaction: t })
         }
 
         // 清除購物車 items
-        await CartItem.destroy({ where: { CartId: cart.id } })
+        await CartItem.destroy({ where: { CartId: cart.id }, transaction: t })
 
         return order
       })

--- a/lib/order_helper.js
+++ b/lib/order_helper.js
@@ -51,8 +51,8 @@ module.exports = {
         })
 
         // 加入單號 SN
-        const sn = ("000000000" + order.id).slice(-10)
-        await order.update({ sn })
+        order.sn = ("000000000" + order.id).slice(-10)
+        await order.save()
 
         // Create OrderItem
         const cart = data.cart

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,11 +10,6 @@ const { isAuth } = require('../middleware/auth.js')
 const { getCategoryBar } = require('../middleware/category.js')
 const { getTagGroup } = require('../middleware/tag.js')
 
-const db = require('../models')
-const Op = db.Sequelize.Op
-const { Product } = db
-const { checkInv, txnOrder } = require('../lib/order_helper.js')
-
 module.exports = app => {
   app.use('/admin', require('./admin/index.js'))
   app.post('/newebpay/callback', newebpayCb)  // 金流API callback
@@ -28,36 +23,4 @@ module.exports = app => {
 
   app.get('/', (req, res) => res.redirect('/products'))
   app.get('/search', getTagGroup, require('../controllers/prodCtrller').getProducts)
-
-  app.get('/test', async (req, res) => {
-    const cartProds = [
-      { id: 1, CartItem: { quantity: 1 }},
-      // { id: 2, CartItem: { quantity: 1 }},
-      { id: 3, CartItem: { quantity: 1 }},
-    ]
-    const queryArray = cartProds.map(prod => ({ id: prod.id }))
-
-    try {
-      // 檢查商品庫存
-      const products = await Product.findAll(
-        { where: { [Op.or]: queryArray } }
-      )
-
-      const error = checkInv(products, cartProds)
-      if (error) {
-        req.flash('error', error)
-        return res.redirect('/cart')
-      }
-      
-      // 成立訂單 by transaction
-      const txnError = await txnOrder()
-      if (txnError) { throw txnError }
-
-      res.send('fin')
-    } catch (error) {
-      console.log(error.toString())
-      res.send('error')
-    }
-  })
 }
-

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,6 +10,9 @@ const { isAuth } = require('../middleware/auth.js')
 const { getCategoryBar } = require('../middleware/category.js')
 const { getTagGroup } = require('../middleware/tag.js')
 
+const db = require('../models')
+const { Product } = db
+
 module.exports = app => {
   app.use('/admin', require('./admin/index.js'))
   app.post('/newebpay/callback', newebpayCb)  // 金流API callback
@@ -23,4 +26,13 @@ module.exports = app => {
 
   app.get('/', (req, res) => res.redirect('/products'))
   app.get('/search', getTagGroup, require('../controllers/prodCtrller').getProducts)
+
+  app.get('/test', (req, res) => {
+    const productMap = [1, 2, 3]
+    productMap.forEach(id => {
+      Product.decrement({ inventory: 1 }, { where: { id } })
+    })
+
+    res.send('fin')
+  })
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -11,7 +11,9 @@ const { getCategoryBar } = require('../middleware/category.js')
 const { getTagGroup } = require('../middleware/tag.js')
 
 const db = require('../models')
+const Op = db.Sequelize.Op
 const { Product } = db
+const { checkInv, txnOrder } = require('../lib/order_helper.js')
 
 module.exports = app => {
   app.use('/admin', require('./admin/index.js'))
@@ -27,12 +29,35 @@ module.exports = app => {
   app.get('/', (req, res) => res.redirect('/products'))
   app.get('/search', getTagGroup, require('../controllers/prodCtrller').getProducts)
 
-  app.get('/test', (req, res) => {
-    const productMap = [1, 2, 3]
-    productMap.forEach(id => {
-      Product.decrement({ inventory: 1 }, { where: { id } })
-    })
+  app.get('/test', async (req, res) => {
+    const cartProds = [
+      { id: 1, CartItem: { quantity: 1 }},
+      // { id: 2, CartItem: { quantity: 1 }},
+      { id: 3, CartItem: { quantity: 1 }},
+    ]
+    const queryArray = cartProds.map(prod => ({ id: prod.id }))
 
-    res.send('fin')
+    try {
+      // 檢查商品庫存
+      const products = await Product.findAll(
+        { where: { [Op.or]: queryArray } }
+      )
+
+      const error = checkInv(products, cartProds)
+      if (error) {
+        req.flash('error', error)
+        return res.redirect('/cart')
+      }
+      
+      // 成立訂單 by transaction
+      const txnError = await txnOrder()
+      if (txnError) { throw txnError }
+
+      res.send('fin')
+    } catch (error) {
+      console.log(error.toString())
+      res.send('error')
+    }
   })
 }
+


### PR DESCRIPTION
## 更動項
- 扣庫存、建Order、建OrderItem、刪CartItem，整套改用 transaction
  - 並將此區塊拆分到 `lib/order_helper.js`
- 檢查庫存的部份，也拆分到 `lib/order_helper.js`
- 精簡「防不當進入」區塊的 code

幫 postOrder 瘦了一圈。 

## 說明
嘗試使用之前 demo 時，業界評審 Mat 提到的 transaction 來改寫。
這東西概念很簡單，[sequelize](https://sequelize.org/master/manual/transactions.html) 已經包好 function 了，大概這種感覺。
```
sequelize.transaction(async t => {
  // 扣庫存
  // 建立 Order
  // 建立 OrderItem
})
```

只要有一個失敗，就會全部還原。

但是我們設計上，希望能回傳「哪件商品」、「庫存剩多少」給使用者，
而 transaction 如果因庫存不夠失敗，只會回傳錯誤訊息，並不會返回該 product 的 data。
所以「檢查庫存」的地方，其實還是得用原本的寫法。

## 確認目標
- 結帳流程應該沒有壞掉
- 加入購物車後，故意從資料庫減少庫存，使其小於購買數量
  - 最終確認時，會被彈回，並返回庫存不夠的商品訊息給 User

ps. transaction 的測試比較麻煩，我這邊確認過了，應該沒問題

